### PR TITLE
Fix incorrect reference

### DIFF
--- a/FoxDot/Settings/__init__.py
+++ b/FoxDot/Settings/__init__.py
@@ -12,7 +12,7 @@ MAC_OS  = 2
 
 if sys.platform.startswith('darwin'):
 
-    SYSTEM = MACOS
+    SYSTEM = MAC_OS
 
 elif sys.platform.startswith('win'):
 


### PR DESCRIPTION
Use `MAC_OS` as used above, rather than `MACOS`.