### PR TITLE
Set the Window's Class Name to `FoxDot`

### DIFF
--- a/FoxDot/lib/Workspace/ConfigFile.py
+++ b/FoxDot/lib/Workspace/ConfigFile.py
@@ -6,7 +6,7 @@ import os.path
 
 class Config:
     def __init__(self, path):
-        self.root = Tk()
+        self.root = Tk(className='FoxDot')
         self.root.title("conf.txt")
 
         try:

--- a/FoxDot/lib/Workspace/Editor.py
+++ b/FoxDot/lib/Workspace/Editor.py
@@ -49,7 +49,7 @@ class workspace:
 
         # Set up master widget  
 
-        self.root = Tk()
+        self.root = Tk(className='FoxDot')
         self.root.title("FoxDot - Live Coding with Python and SuperCollider")
         self.root.rowconfigure(0, weight=1) # Text box
         self.root.rowconfigure(1, weight=0) # Separator


### PR DESCRIPTION
The default WM_CLASS for Tkinter windows is set to `Tk`. This becomes
inconvenient in tiling window managers, where you may want to assign
FoxDot to a specific workspace/tag, as attempting to match by `Tk` will
assign all Tk applications to that tag. Changing the WM_CLASS attribute
via the `className` argument to the `Tk` constructors allows users to
match & assign only FoxDot windows.