### PR TITLE
Added PEuclid2 that generates lists of arbitrary elements

### DIFF
--- a/FoxDot/lib/Patterns/Sequences.py
+++ b/FoxDot/lib/Patterns/Sequences.py
@@ -24,7 +24,7 @@ MAX_SIZE = 2048
 #==============================#
 #         1. P[] & P()         #
 #==============================#
- 
+
 class __pattern__(object):
     ''' Used to define lists as patterns:
 
@@ -50,7 +50,7 @@ class __pattern__(object):
         else:
             data = args
         return Pattern(data)
-    
+
     def __call__(self, *args):
         return PGroup(args if len(args) > 1 else args[0])
 
@@ -85,9 +85,9 @@ class __pattern__(object):
 class __reverse_pattern__(__pattern__):
     def __getattr__(self, name):
         return ~object.__getattr__(self, name)
-    
 
-# This is a pattern creator  
+
+# This is a pattern creator
 P = __pattern__()
 
 #================================#
@@ -118,7 +118,7 @@ def PStretch(seq, size):
 def PPairs(seq, func=lambda n: 8-n):
     """ Laces a sequence with a second sequence obtained
         by performing a function on the original. By default this is
-        `lambda n: 8 - n`. """        
+        `lambda n: 8 - n`. """
     i = 0
     data = []
     for item in seq:
@@ -199,7 +199,7 @@ def PSum(n, total, **kwargs):
         else:
             data[i % n] += step
             i += 1
-            
+
     return Pattern(data)
 
 @loop_pattern_func
@@ -225,6 +225,16 @@ def PEuclid(n, k):
     ''' Returns the Euclidean rhythm which spreads 'n' pulses over 'k' steps as evenly as possible.
         e.g. `PEuclid(3, 8)` will return `P[1, 0, 0, 1, 0, 0, 1, 0]` '''
     return Pattern( EuclidsAlgorithm(n, k) )
+
+@loop_pattern_func
+def PEuclid2(n, k, lo, hi):
+    ''' Same as PEuclid except it returns an array filled with 'lo' value instead of 0
+        and 'hi' value instead of 1. Can be used to generate characters patterns used to
+        play sample like play(PEuclid2(3,8,'-','X')) will be equivalent to
+        play(P['X', '-', '-', 'X', '-', '-', 'X', '-'])
+        that's like saying play("X--X--X-")
+        '''
+    return Pattern( EuclidsAlgorithm(n, k, lo, hi) )
 
 @loop_pattern_func
 def PDur(n, k, start=0, dur=0.25):

--- a/FoxDot/lib/Utils/__init__.py
+++ b/FoxDot/lib/Utils/__init__.py
@@ -17,7 +17,7 @@ def stdout(*args):
 
 def sliceToRange(s):
     start = s.start if s.start is not None else 0
-    stop  = s.stop 
+    stop  = s.stop
     step  = s.step if s.step is not None else 1
     try:
         return list(range(start, stop, step))
@@ -28,31 +28,31 @@ def LCM(*args):
     """ Lowest Common Multiple """
 
     args = [n for n in args if n != 0]
-    
+
     # Base case
     if len(args) == 0:
         return 1
-    
+
     elif len(args) == 1:
         return args[0]
 
     X = list(args)
-    
+
     while any([X[0]!=K for K in X]):
 
         i = X.index(min(X))
-        X[i] += args[i]        
+        X[i] += args[i]
 
     return X[0]
 
-def EuclidsAlgorithm(n, k):
-    
+def EuclidsAlgorithm(n, k, lo=0, hi=1):
+
     if n == 0: return [n for i in range(k)]
-    
-    data = [[1 if i < n else 0] for i in range(k)]
-    
+
+    data = [[hi if i < n else lo] for i in range(k)]
+
     while True:
-        
+
         k = k - n
 
         if k <= 1:
@@ -64,7 +64,7 @@ def EuclidsAlgorithm(n, k):
         for i in range(n):
             data[i] += data[-1]
             del data[-1]
-    
+
     return [x for y in data for x in y]
 
 
@@ -72,7 +72,7 @@ def modi(array, i, debug=0):
     """ Returns the modulo index i.e. modi([0,1,2],4) will return 1 """
     try:
         return array[i % len(array)]
-    except(TypeError, AttributeError, ZeroDivisionError): 
+    except(TypeError, AttributeError, ZeroDivisionError):
         return array
 
 def get_expanded_len(data):
@@ -92,11 +92,11 @@ def get_expanded_len(data):
 
 def max_length(*patterns):
     """ Returns the largest length pattern """
-    return max([len(p) for p in patterns])  
+    return max([len(p) for p in patterns])
 
 # Classes
 
-class dots:        
+class dots:
     """ Class for representing long Patterns in strings """
     def __repr__(self):
         return '...'


### PR DESCRIPTION
Added PEuclid2 [here](https://github.com/Qirky/FoxDot/compare/master...Psykopear:euclid2-pattern?expand=1#diff-e41b64bbb2760d0fd1fab3254dcadfdbR229) that's like PEuclid only it fills the list with arbitrary values instead of 0 and 1.

So for example `play(PEuclid2(3,8,'-','X'))` it's the same as `play("X--X--X-")`

To do this I changed the signature of [EuclidsAlghorithms](https://github.com/Qirky/FoxDot/compare/master...Psykopear:euclid2-pattern?expand=1#diff-177d8c026b9ae57d7fc939f47dcbc243R48) so it now accepts two kwargs (`lo` and `hi`) that defaults to 0 and 1.
In this way it can still be called without kwargs having the same result, but if kwargs are supplied they will be used instead.

Also, deleted trailing whitespaces.