### PR TITLE
Lazy-load buffers, and support more complex loading

### DIFF
--- a/FoxDot/lib/Buffers.py
+++ b/FoxDot/lib/Buffers.py
@@ -22,6 +22,7 @@ from itertools import chain
 from os.path import abspath, join, isabs, isfile, isdir, splitext
 
 from .Code import WarningMsg
+from .Logging import Timing
 from .SCLang import SampleSynthDef
 from .ServerManager import DefaultServer
 from .Settings import FOXDOT_SND, FOXDOT_LOOP
@@ -335,6 +336,7 @@ class BufferManager(object):
             return candidates[index % len(candidates)]
         return None
 
+    @Timing('bufferSearch', logargs=True)
     def _findSample(self, filename, index=0):
         """
         Find a sample from a filename or pattern

--- a/FoxDot/lib/Logging.py
+++ b/FoxDot/lib/Logging.py
@@ -1,0 +1,97 @@
+""" Utilities related to logging """
+import inspect
+import functools
+import logging
+import time
+
+
+def enablePerfLogging():
+    """ This is just a small convenience method """
+    logging.getLogger('FoxDot.perf').setLevel(logging.DEBUG)
+
+
+class Timing(object):
+    """
+    Utility for profiling events
+
+    :param str event: Unique identifier for the perf event
+    :param str logger: Logger path (default 'FoxDot.perf')
+    :param bool logargs: If true when used as a decorator, log the arguments to
+        the decorated function
+
+    This can be used in multiple ways. As a decorator::
+
+        @Timing('fibonacci')
+        def fib(num):
+            ...
+
+    As a context manager::
+
+        with Timing('pi'):
+            # calculate pi...
+
+    Or directly as an object::
+
+        timer = Timing('crank')
+        # do crank
+        timer.finish()
+
+    Note that it will log the perf data to the specified logger (FoxDot.perf by
+    default) at the DEBUG level. That means that in order for the information
+    to be visible, you will need to configure either that logger or a parent
+    logger to use the DEBUG level. For example::
+
+        # Set root logger to DEBUG
+        logging.root.setLevel(logging.DEBUG)
+        # Set just the perf logger to DEBUG
+        logging.getLogger('FoxDot.perf').setLevel(logging.DEBUG)
+
+    """
+
+    def __init__(self, event, logger='FoxDot.perf', logargs=False):
+        self._event = event
+        self._logger = logger
+        self._log = logging.getLogger(logger)
+        self._messages = []
+        self._start = None
+        self._logargs = logargs
+
+    def __str__(self):
+        return "Timing(%s)" % self._event
+
+    def addMessage(self, message):
+        self._messages.append(message)
+
+    def start(self):
+        if self._start is not None:
+            self._log.warn("Entering %s twice!", self)
+        self._start = time.time()
+
+    def finish(self):
+        if self._start is None:
+            self._log.warn("Finishing %s before start!", self)
+            return
+        diff = 1000 * (time.time() - self._start)
+        formatted_messages = ''
+        if self._messages:
+            formatted_messages = ', '.join(self._messages) + ': '
+        self._log.debug("%s: %s%.02fms", self._event, formatted_messages, diff)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.finish()
+
+    def __call__(self, fxn):
+        @functools.wraps(fxn)
+        def wrapper(*args, **kwargs):
+            with Timing(self._event, self._logger) as timer:
+                if self._logargs:
+                    if args:
+                        timer.addMessage("args:%s" % list(args))
+                    if kwargs:
+                        timer.addMessage("kwargs:%s" % kwargs)
+                return fxn(*args, **kwargs)
+        return wrapper

--- a/FoxDot/lib/Players.py
+++ b/FoxDot/lib/Players.py
@@ -1319,7 +1319,7 @@ class Player(Repeatable):
 
                 pos = 0 
  
-            buf  = int(self.samples[str(degree)].bufnum(sample))
+            buf  = self.samples.getBufferFromSymbol(str(degree), sample).bufnum
             
             message = {'buf': buf, 'pos': pos}
 

--- a/FoxDot/lib/ServerManager.py
+++ b/FoxDot/lib/ServerManager.py
@@ -165,6 +165,7 @@ class SCLangServerManager(ServerManager):
         self.num_output_busses = 2
         self.bus = self.num_input_busses + self.num_output_busses
         self.max_busses = 100
+        self.max_buffers = 1024
 
         self.fx_setup_done = False
         self.fx_names = {}
@@ -179,6 +180,7 @@ class SCLangServerManager(ServerManager):
             # It's not terrible if we couldn't fetch the info, but we should log it.
             WarningMsg("Could not fetch info from SCLang server. Using defaults...")
         else:
+            self.max_buffers = info.num_buffers
             self.num_input_busses = info.num_input_bus_channels
             self.num_output_busses = info.num_output_bus_channels
             self.max_busses = info.num_audio_bus_channels
@@ -522,6 +524,12 @@ class SCLangServerManager(ServerManager):
         message.append([bufnum, path])
         self.client.send( message )
         return
+
+    def bufferFree(self, bufnum):
+        """ Sends a message to SuperCollider to free a buffer """
+        message = OSCMessage("/b_free")
+        message.append([bufnum])
+        self.client.send(message)
 
     def sendMidi(self, msg, cmd="/foxdot_midi"):
         """ Sends a message to the FoxDot class in SuperCollider to forward a MIDI message """

--- a/FoxDot/lib/__init__.py
+++ b/FoxDot/lib/__init__.py
@@ -17,6 +17,8 @@ Copyright Ryan Kirkbride 2015
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from .Code import *
 
 FoxDotCode.namespace = globals()
@@ -141,6 +143,7 @@ def Master():
 
 # Create a clock and define functions
 
+logging.basicConfig(level=logging.ERROR)
 when.set_namespace(FoxDotCode) # experimental
 
 Clock = TempoClock()

--- a/Tutorial/3_StarterGuide.md
+++ b/Tutorial/3_StarterGuide.md
@@ -156,7 +156,61 @@ The PTri class does this for you:
 george >> pluck(PTri(5), scale=Scale.default.pentatonic)
 ```
 
-## 5. TimeVars
+## 5. Samples
+
+You saw earlier how to work with samples using `play()`. You can also play samples with `loop()`.
+
+```python
+s1 >> loop('foxdot')
+```
+
+You may notice that this is just playing the first part of the sample over and
+over again. You can tweak the behavior with many of the arguments we've seen
+thus far for controlling other synths. `dur` is a good place to start.
+
+```python
+s1 >> loop('foxdot', dur=4)
+```
+
+If you have a folder full of samples that you would like to use in FoxDot, you
+can call `loop()` with the full path to the sample.
+
+```python
+s1 >> loop('/path/to/samples/quack.wav')
+```
+
+If you give loop the path to a folder, it will play the first sample it finds.
+You can change which sample it plays with the `sample=` arg.
+
+```python
+# Play the first sample in my collection
+s1 >> loop('/path/to/samples')
+# Play the second sample in my collection
+s1 >> loop('/path/to/samples', sample=1)
+```
+
+If you're going to be using a lot of samples from a folder, you can add it to
+the sample search path. FoxDot will look under all its search paths for a
+matching sample when you give it a name.
+
+```python
+Samples.addPath('/path/to/samples')
+s1 >> loop('quack')
+```
+
+Once you have a search path, you can use pattern matching to search for samples.
+
+```python
+# Play the 3rd sample under the 'snare' dir
+s1 >> loop('snare/*', sample=2)
+# You can use * in directory names too
+s1 >> loop('*_120bpm/drum*/kick*')
+# ** means "all recursive subdirectories". This will play the first sample
+# nested under 'percussion' (e.g. 'percussion/kicks/classic/808.wav')
+s1 >> loop('percussion/**/*')
+```
+
+## 6. TimeVars
 
 A TimeVar is an abbreviation of "Time Dependent Variable" and is a key feature of FoxDot. A TimeVar has a series of values that it changes between after a pre-defined number of beats and is created using a var object with the syntax `var([list_of_values],[list_of_durations])`. Example:
 

--- a/Tutorial/3_StarterGuide.md
+++ b/Tutorial/3_StarterGuide.md
@@ -2,22 +2,7 @@
 
 ## 1. Installation and set up
 
-FoxDot currently requires Python 2.7 and SuperCollider 3.6 to be installed and has been developed for use on Windows machines. FoxDot does work on Linux and Mac operating systems but has not been tested thoroughly. Please report any issues or bugs on the GitHub.
-
-### Downloads:
-
-Python 2.7
-SuperCollider 3.6
-Once you have Python and SuperCollider correctly installed, you can download FoxDot as a .zip file by click here:
-
-Download FoxDot
-
-Configuration
-
-Open FoxDot/Settings/conf.txt
-Change the value of SUPERCOLLIDER to the directory where SuperCollider is installed
-Install the UbuntuMono-R.ttf font, or change the FONT value in the configuration file
-Finally, run main.py (found in the FoxDot-master folder you've just extracted) and you're good to go!
+See [the main README](https://github.com/stevearc/FoxDot/blob/master/README.md) for installation instructions
 
 ## 2. Programming with Python and Sound in SuperCollider
 
@@ -25,122 +10,177 @@ Python is an object-oriented programming language that focusses on flexibility a
 
 If you're ever stuck, or want to know more about a function or class - just type help followed by the name of that Python object in brackets:
 
+```python
 help(object)
+```
+
 FoxDot provides a Python interface to SuperCollider - mainly as a quick and easy to use abstraction for SuperCollider classes, Pbind and SynthDef. Please read the SuperCollider documentation if you'd like to know more.
 
 A SynthDef is essentially your digital instrument and FoxDot creates players that use these instruments with your guidance. To execute code in FoxDot, make sure your text cursor is in the 'block' of code (sections of text not separated by blank lines) and press Ctrl+Return. The output of any executed code is displayed in the console in the bottom half of the window.
 
-Try print 2+2 and see what you get.
+Try `print(2+2)` and see what you get.
 
 Now try something that spans multiple lines:
 
+```python
 for n in range(10):
     sq = n*n
-    print n, sq 
+    print(n, sq)
+```
 
 ## 3. Player Objects
 
 It is, in fact, possible to create SuperCollider SynthDefs using FoxDot, but that's outside of the scope of the workshop today - don't hesitate to ask if you'd like to more though. To have a look at the existing (but quite small, unfortunately) library of FoxDot SynthDefs, just execute:
 
-print SynthDefs
+```python
+print(SynthDefs)
+```
+
 Choose one and create a FoxDot player object using the double arrow syntax like in the example below. If my chosen SynthDef was "pluck" then I could create an object "p1":
 
+```python
 p1 >> pluck()
-To stop an individual player object, simply execute p1.stop(). To stop all player objects, you can press Ctrl+., which is a shortcut for the command Clock.clear().
+```
 
-The >> in Python is usually reserved for a type of operation, like + or -, but it is not the case in FoxDot, and the reason will become clear shortly. If you now give your player object some arguments, you can change the notes being played back. The first argument, the note degree, doesn't need explicit naming, but you'll need to specify whatever else you want to change - such as note durations or amplitudes.
+To stop an individual player object, simply execute `p1.stop()`. To stop all player objects, you can press Ctrl+., which is a shortcut for the command `Clock.clear()`.
 
+The `>>` in Python is usually reserved for a type of operation, like `+` or `-`, but it is not the case in FoxDot, and the reason will become clear shortly. If you now give your player object some arguments, you can change the notes being played back. The first argument, the note degree, doesn't need explicit naming, but you'll need to specify whatever else you want to change - such as note durations or amplitudes.
+
+```python
 p1 >> pluck([0,2,4], dur=[1,1/2,1/2], amp=[1,3/4,3/4])
+```
+
 These keyword arguments relate to the corresponding SynthDef ("pluck" in this case) but with a few exceptions:
 
-degree
-dur
-scale
+degree  
+dur  
+scale  
 oct
-These are used by FoxDot to calculate the frequencies of notes to be played and when to play them. You can view the SuperCollider code (although not easy to read) by executing print SynthDefs['pluck'] or print SynthDefs('pluck') with the SynthDef of your choosing. You can group together sounds by putting multiple values within an argument in round brackets like so:
 
+These are used by FoxDot to calculate the frequencies of notes to be played and when to play them. You can view the SuperCollider code (although not easy to read) by executing `print(SynthDefs['pluck'])` or `print(SynthDefs('pluck'))` with the SynthDef of your choosing. You can group together sounds by putting multiple values within an argument in round brackets like so:
+
+```python
 b >> bass([(0,9),(3,7)], dur=4, pan=(-1,1))
+```
 Notice how you don't need to put single values in square brackets? FoxDot takes care of that for you. You can even have a Player Object follow another!
 
+```python
 b >> bass([0,2,3,4], dur=4)
 p >> pluck(dur=1/2).follow(b) + (0,2,4) # This adds a triad to the bass notes
+```
 
 Sound samples can also be played back using the Sample Player object, which is created like so:
 
+```python
 d >> play("x-o-")
+```
+
 Each character refers to a different audio file. To play samples simultaneously, simply create a new player object:
 
+```python
 d1 >> play("xxox")
 hh >> play("---(-=)", pan=0.5)
-Characters in round brackets are alternated in each loop (know as lacing) such that the above player, 'hh', would be writtern literally as hh >> play('-------=') which save you a lot of typing! Putting characters in square brackets will play them twice as fast and can be put in round brackets as if they were one character themselves. Try it out:
+```
 
+Characters in round brackets are alternated in each loop (know as lacing) such that the above player, 'hh', would be writtern literally as `hh >> play('-------=')` which save you a lot of typing! Putting characters in square brackets will play them twice as fast and can be put in round brackets as if they were one character themselves. Try it out:
+
+```python
 d1 >> play("x[--]o(=[-o])")
+```
 
 ## 4. Patterns
 
 Player Objects use Python lists, known more commonly as arrays in other languages, to sequence themselves. You've already used these previously, but they aren't exactly flexible for manipulation. For example, try multiplying a list by two like so:
 
-print [1, 2, 3] * 2
+```python
+print([1, 2, 3] * 2)
+```
+
 Is the result what you expected? If you want to manipulate the internal values in Python you have to use a for loop:
 
+```python
 l = []
 for i in [1, 2, 3]:
     l.append(i * 2)
-print l
+print(l)
+```
+
 or list comprehension:
 
-print [i*2 for i in [1,2,3]]
+```python
+print([i*2 for i in [1,2,3]])
+```
+
 But what if you want to multiply the values in a list by 2 and 3 in an alternating way? That requires quite a lot of messing around actually, especially if you don't know what values you'll be using. FoxDot uses a container type called a 'Pattern' to help solve this problem. They act like regular lists but any mathematical operation performed on it is done to each item in the list and done so pair-wise if using a second pattern. The base Pattern can be created like so:
 
+```python
 print P([1,2,3]) * 2
 >>> [2, 4, 6]
 print P([1,2,3]) + [3,4]
 >>> [4, 6, 6, 5, 5, 7]
+```
+
 Notice how in the second operation, the output consists of all the combinations of the two patterns i.e. [1+3, 2+4, 3+3, 1+4, 2+3, 3+4].
 
 Try some other mathematical operators and see what results you get.
-What happens when you group numbers in brackets, like P([1,2,3]]) * (1,2)?
-There are several other Pattern classes in FoxDot that help you generate arrays of numbers but also behave in the same way as the base Pattern. We'll just look at two types here, but execute print classes(Patterns.Sequences) to see what others exist and have a go at using them.
+What happens when you group numbers in brackets, like `P([1,2,3]]) * (1,2)`?
+There are several other Pattern classes in FoxDot that help you generate arrays of numbers but also behave in the same way as the base Pattern. We'll just look at two types here, but execute `print(classes(Patterns.Sequences))` to see what others exist and have a go at using them.
 
-In Python, you can generate a range of integers with the syntax range(start, stop, step). By default, start is 0 and step is 1. You can use PRange(start, stop, step) to create a Pattern object with the equivalent values:
+In Python, you can generate a range of integers with the syntax range(start, stop, step). By default, start is 0 and step is 1. You can use `PRange(start, stop, step)` to create a Pattern object with the equivalent values:
 
-print range(10)
+```python
+print(range(10))
 >>> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-print PRange(10)
+print(PRange(10))
 >>> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-print PRange(10) * [1, 2]           # Pattern class behaviour
+print(PRange(10) * [1, 2])          # Pattern class behaviour
 >>> [0, 2, 2, 6, 4, 10, 6, 14, 8, 18]
+```
+
 But what about combining patterns? In Python, you can concatenate two lists (append one to another) by using the + operator but FoxDot Patterns use this to perform addition to the data within the list. To connect two Pattern objects together, you can use the pipe symbol, |, which Linux users might be familiar with - it is used to connect command line programs by sending output from one process as input to another.
 
-print PRange(4) | [1,7,6]
+```python
+print(PRange(4) | [1,7,6])
 >>> [0, 1, 2, 3, 1, 7, 6]
+```
+
 FoxDot automatically converts any object being piped to a Pattern to the base Pattern class so you don't have to worry about making sure everything is the right type. There exists several types of Pattern sequences in FoxDot (and the list is still growing) that make generating these numbers a little easier. For example, to play the first octave of a pentatonic scale from bottom to top and back again, you might use two PRange objects:
 
+```python
 george >> pluck(PRange(5) | PRange(5,0,-1), scale=Scale.default.pentatonic)
+```
+
 The PTri class does this for you:
 
+```python
 george >> pluck(PTri(5), scale=Scale.default.pentatonic)
+```
 
 ## 5. TimeVars
 
-A TimeVar is an abbreviation of "Time Dependent Variable" and is a key feature of FoxDot. A TimeVar has a series of values that it changes between after a pre-defined number of beats and is created using a var object with the syntax var([list_of_values],[list_of_durations]). Example:
+A TimeVar is an abbreviation of "Time Dependent Variable" and is a key feature of FoxDot. A TimeVar has a series of values that it changes between after a pre-defined number of beats and is created using a var object with the syntax `var([list_of_values],[list_of_durations])`. Example:
 
+```python
 a = var([0,3],4)            # Duration can be single value
-print int(Clock.now()), a   # 'a' initally has a value of 0
+print(int(Clock.now()), a)  # 'a' initally has a value of 0
 >>> 0, 0
-print int(Clock.now()), a   # After 4 beats, the value changes to 3
+print(int(Clock.now()), a)  # After 4 beats, the value changes to 3
 >>> 4, 3
-print int(Clock.now()), a   # After another 4 beats, the value changes to 0
+print(int(Clock.now()), a)  # After another 4 beats, the value changes to 0
 >>> 8, 0
+```
+
 When a TimeVar is used in a mathematical operation, the values it affects also become TimeVars that change state when the original TimeVar changes state - this can even be used with patterns:
 
+```python
 a = var([0,3], 4)
-print a + 5         # beat = 0
+print(a + 5)        # beat = 0
 >>> 5
-print a + 5         # beat = 4
+print(a + 5)        # beat = 4
 >>> 8
 b = Prange(4) + a
-print b             # beat = 8 ('a' now has the value of 0)
+print(b)            # beat = 8 ('a' now has the value of 0)
 >>> [0, 1, 2, 3]
-print b             # beat = 12 ('a'  now has the value of 3)
+print(b)            # beat = 12 ('a'  now has the value of 3)
 >>> [3, 4, 5, 6]
+```

--- a/docs/Buffers.md
+++ b/docs/Buffers.md
@@ -13,13 +13,6 @@ that can be proggrammed into performance.
 
 ## Classes
 
-### `BufChar(self, char)`
-
-
-
-#### Methods
-
----
 
 ### `Buffer(self, fn, number, channels=1)`
 
@@ -37,13 +30,6 @@ that can be proggrammed into performance.
 
 ---
 
-### `LoopFile(self, char)`
-
-
-
-#### Methods
-
----
 
 ### `LoopSynthDef(self)`
 
@@ -71,9 +57,6 @@ Writes the SynthDef to file
 
 ## Functions
 
-### `FindBuffer(name)`
-
-None
 
 ### `path(fn)`
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,0 +1,109 @@
+""" Tests for BufferManager """
+import os
+import shutil
+import tempfile
+import unittest
+from os.path import join
+
+from FoxDot.lib.Buffers import BufferManager
+
+
+class TestSampleSearch(unittest.TestCase):
+
+    """ Test search functionality for sample files """
+    def setUp(self):
+        super(TestSampleSearch, self).setUp()
+        def mkdir(dirname):
+            os.mkdir(join(self.wd, dirname))
+        def touch(filename):
+            fullpath = join(self.wd, filename)
+            open(fullpath, 'w').close()
+            return fullpath
+        self.wd = tempfile.mkdtemp()
+        self.bm = BufferManager()
+        self.bm._paths = [self.wd]
+        self._yeah = touch('yeah.wav')
+        mkdir('snares')
+        self._snare1 = touch('snares/snare1.wav')
+        self._snare2 = touch('snares/snare2.wav')
+        mkdir('kicks')
+        self._808 = touch('kicks/808.wav')
+        self._kick = touch('kicks/kick.wav')
+        mkdir('kicks/house')
+        self._housekick = touch('kicks/house/house_bass.wav')
+
+    def tearDown(self):
+        super(TestSampleSearch, self).tearDown()
+        shutil.rmtree(self.wd)
+
+    def test_abspath(self):
+        """ Sample file as absolute path """
+        sample = join(self.wd, 'yeah.wav')
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, sample)
+
+    def test_abspath_no_ext(self):
+        """ Sample file as absolute path with no extension """
+        sample = join(self.wd, 'yeah')
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._yeah)
+
+    def test_relpath(self):
+        """ Sample file as relative path """
+        sample = 'yeah.wav'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._yeah)
+
+    def test_relpath_no_ext(self):
+        """ Sample file as relative path with no extension """
+        sample = 'yeah'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._yeah)
+
+    def test_dir_first(self):
+        """ Sample directory load first sample """
+        sample = 'snares'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._snare1)
+
+    def test_dir_nth(self):
+        """ Sample directory load nth sample """
+        sample = 'snares'
+        found = self.bm._findSample(sample, 1)
+        self.assertEqual(found, self._snare2)
+
+    def test_dir_nth_overflow(self):
+        """ Sample directory load nth sample (exceeds count) """
+        sample = 'snares'
+        found = self.bm._findSample(sample, 2)
+        self.assertEqual(found, self._snare1)
+
+    def test_nested_filename(self):
+        """ Sample filename loaded from nested dir """
+        sample = 'snare1.wav'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._snare1)
+
+    def test_nested_filename_no_ext(self):
+        """ Sample filename with no extension loaded from nested dir """
+        sample = 'snare1'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._snare1)
+
+    def test_pathpattern(self):
+        """ Sample specified as pattern with path elements """
+        sample = 'k?c*/*'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._808)
+
+    def test_pathpattern_doublestar(self):
+        """ Sample specified as pattern containing /**/ """
+        sample = '**/snare*'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._snare1)
+
+    def test_doublestar_deep_path(self):
+        """ Sample specified as pattern containing /**/path """
+        sample = '**/house/*'
+        found = self.bm._findSample(sample)
+        self.assertEqual(found, self._housekick)


### PR DESCRIPTION
This change reworks how buffers are loaded. Instead of loading them all into SC on startup, they are loaded in on-demand. This opens up the ability to have a much larger sample library without overrunning the max buffers.

A large part of the diff is adding the capability to load samples from more locations. You can now play samples by specifying them directly (with or without the extension):
```python
a1 >> loop("/path/to/sample.wav")
a2 >> loop("/path/to/sample")
```
There's also support for adding search paths. That's the `self._paths` attribute, which only contains the `FOXDOT_LOOP` directory by default. There's no interface support for adding paths yet, but it's easy to call `Samples.addPath('/my/samples/dir')`. You can put in all kinds of path patterns for the sample and it will recursively search for a match in all of your search paths

```python
a1 >> loop("yeah")             # Searches recursively for yeah.(wav|wave|aif|aiff|flac)
a1 >> loop("perc/kick")        # Supports directories in the path
a1 >> loop("*kick*", sample=2) # Supports * ? [chars] and [!chars]
a1 >> loop("**/*_Em")          # Supports ** as 'recursively all subdirectories'
```

The functionality of `play()` should be unchanged.

I also added some tests that can be run with `python -m unittest tests.test_buffers`

I'm next planning on adding support for customizing the samples for the `play()` symbols, and some rudimentary save/load support.