### PR TITLE
Fix for tuning index lookup in microtonal scales

### DIFF
--- a/FoxDot/lib/Scale.py
+++ b/FoxDot/lib/Scale.py
@@ -128,7 +128,7 @@ class ScalePattern(ScaleType, Pattern):
         return Pattern(tones)
 
     def get_tuned_note(self, degree):
-        tuning_index = int(self[degree]) % self.steps
+        tuning_index = int(self[degree]) % len(self.tuning)
         # tuning_offset = 0
         # if degree < 0:
         #     tuning_offset = (((abs(degree) // len(self.tuning)) + 1) * self.steps)


### PR DESCRIPTION
I was having some issues with using 22-EDO, where the scale would repeat at degree 12. From what I can see, the issue is with the `get_tuned_note` method - I think the modulo should be with respect to the length of the tuning array, not the steps variable which represents the interval between octaves.