### PR TITLE
Improvements for VRender

### DIFF
--- a/FoxDot/lib/Extensions/VRender/Composer.py
+++ b/FoxDot/lib/Extensions/VRender/Composer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 from .MidiFactory import createMidi
 import os
+from math import ceil
 
 def extendScale(scale,times):
     scaleAux = scale[:]
@@ -10,6 +11,16 @@ def extendScale(scale,times):
             scale.append(note+12*i)
     return scale
 
+def matchListsSize(rhythm,melody):
+    n_rhythm =len(rhythm)
+    n_melody = len(melody)
+    if n_rhythm < n_melody:
+        rhythm = (rhythm*int(ceil(n_melody/float(n_rhythm))))[:n_melody]
+    elif n_rhythm != n_melody:
+        melody = (melody*int(ceil(n_rhythm/float(n_melody))))[:n_rhythm]
+
+    return rhythm,melody
+
 def toList(rhythm, melody, scale):
 
     scale = extendScale(scale,2)
@@ -17,6 +28,8 @@ def toList(rhythm, melody, scale):
 
     volume = 100
     baseNote = 60
+
+    rhythm, melody = matchListsSize(rhythm,melody)
 
     composition = []
     time = 0

--- a/FoxDot/lib/Extensions/VRender/Constants.py
+++ b/FoxDot/lib/Extensions/VRender/Constants.py
@@ -1,9 +1,0 @@
-# Constants
-FILES_ROOT = "lib/Extensions/VRender/tmp/"
-LAST_MIDI = FILES_ROOT + "last_midi_generated_by_vrender.mid"
-VOICE_XML_ORIGINAL=FILES_ROOT + "last_voice.musicxml"
-VOICE_XML_PROCESSED=FILES_ROOT+"last_voice.xml"
-
-WAVS_ROOT = "snd/_loop_/"
-LAST_VOICE_WAV = WAVS_ROOT + "last_voice_generated.wav"
-

--- a/FoxDot/lib/Extensions/VRender/README.md
+++ b/FoxDot/lib/Extensions/VRender/README.md
@@ -1,7 +1,7 @@
 # Background
 I wanted to add a voice to my Live Coding compositions so I made some research and I learned about singing synthesis, something not so popular in the occidental world but quite popular in japan, with some really successful brands such as Vocaloid.
 
-Looking for open source singing synthezisers, I found sinsy.jp, It is a website made by people from Nagoya Institute of Technology to convert music sheets (In musicXML format) into a singing voice. This is an open source project, I tried to use it locally but it doesn't have as good quality as the web version, probably it needs some configuration or training that I am not aware of.
+Looking for open source singing synthesizers, I found sinsy.jp, It is a website made by people from Nagoya Institute of Technology to convert music sheets (In musicXML format) into a singing voice. This is an open source project, I tried to use it locally but it doesn't have as good quality as the web version, probably it needs some configuration or training that I am not aware of.
 
 # Description
 The feature basically converts the notes and durations into a MIDI file, then converts it to a musicXML with musescore and the lyrics are added with a python script. Finally it makes a request to sinsy.jp to create the WAV file.
@@ -29,7 +29,7 @@ The feature provides the method vrender which has the following parameters
 
 A demonstration video can be found [here](https://youtu.be/cgZuO78tVVE) (The command usage in the video is outdated, the interface is a little bit more simple now).
 
-### Command description, with default values
+### Command description with default values
 ```
 vrender(NOTES, file="v1", lyrics="o", dur=[1],sex="female")
 
@@ -39,6 +39,7 @@ There might be more notes than specified words or durations, in that case those 
 
 
 ### Example using all parameters
+
 ```
 from .Extensions.VRender import vrender # Import vrender
 
@@ -49,7 +50,8 @@ v1 >> loop('wavName',P[4:12],dur=1) # Play it
 ```
 
 
-### Example using only the notes
+### Example specifying only the notes
+
 ```
 from .Extensions.VRender import vrender
 
@@ -59,8 +61,11 @@ v1 >> loop('v1',P[4:12],dur=1)
 
 ```
 
-If you play an audio sample, then overwrite the sample and try to play it again it will probably play the older one. To fix these you can use the command free, to clean the foxdot buffers.
+As you may note in the example, the loop command starts playing the audio in the fourth BPM (P[4:12]), it's because the audio is generated with an initial silence of 4 beats. It might be fixed in the future.
 
+### Cleaning buffers to overwrite audio samples
+
+If you play an audio sample and after that you overwrite the sample and try to play it again it will probably play the older one. To fix these you can use the command free, to clean the foxdot buffers.
 
 ```
 from .Extensions.VRender import vrender
@@ -74,5 +79,3 @@ v2 >> loop('v2',P[4:12],dur=1)
 
 
 ```
-
-As you may note in the example, the loop command starts playing the audio in the fourth BPM (P[4:12]), it's because the audio is generated with an initial silence of 4 beats. It might be fixed in the future.

--- a/FoxDot/lib/Extensions/VRender/README.md
+++ b/FoxDot/lib/Extensions/VRender/README.md
@@ -22,16 +22,16 @@ There are some dependencies in the code, such as python libraries, shell command
 
 The feature provides the method vrender which has the following parameters
 - notes: specifies the notes
-- file: the name of the wav file which is then reproduced with a loop or play method (Optional: Creates a file called "v1.wav" by default)
-- dur: specifies duration of each note (Optional: All notes take 1 BPM by default)
-- lyrics: Is a string which is then splitted by spaces and mapped to each note. (Optional: Just says "oooooo" by default)
+- file: the name of the wav file which is then reproduced with a loop or play method (Optional, creates a file called "v1.wav" by default)
+- lyrics: Is a string which is then splitted by spaces and mapped to each note. (Optional, just says "oooooo" by default)
+- dur: specifies duration of each note (Optional, all notes take 1 BPM by default)
 - sex: "female" or "male" (Optional, female by default)
 
 A demonstration video can be found [here](https://youtu.be/cgZuO78tVVE) (The command usage in the video is outdated, the interface is a little bit more simple now).
 
 ### Command description with default values
 ```
-vrender(NOTES, file="v1", lyrics="o", dur=[1],sex="female")
+vrender(NOTES, file="v1", lyrics="o", dur=[1], sex="female")
 
 ```
 
@@ -43,9 +43,9 @@ There might be more notes than specified words or durations, in that case those 
 ```
 from .Extensions.VRender import vrender # Import vrender
 
-vrender([0,2,0,4], file="wavName", lyrics="hey ho lets go", dur=[1,1,1,1],sex="male") # Generate voice audio file
+vrender([0,2,0,4], file="wavName", lyrics="hey ho lets go", dur=[1,1,1,1], sex="male") # Generate voice audio file
 
-v1 >> loop('wavName',P[4:12],dur=1) # Play it
+v1 >> loop('wavName', P[4:12], dur=1) # Play it
 
 ```
 
@@ -57,7 +57,7 @@ from .Extensions.VRender import vrender
 
 vrender([3,2,1,0,4,4,4,4])
 
-v1 >> loop('v1',P[4:12],dur=1)
+v1 >> loop('v1', P[4:12], dur=1)
 
 ```
 

--- a/FoxDot/lib/Extensions/VRender/README.md
+++ b/FoxDot/lib/Extensions/VRender/README.md
@@ -21,12 +21,11 @@ There are some dependencies in the code, such as python libraries, shell command
 # Usage
 
 The feature provides the method vrender which has the following parameters
-- name: the name of the wav file which is then reproduced with a loop or play method
-- dur: specifies duration of each note
 - notes: specifies the notes
-- lyrics: Is a string which is splitted by spaces
-- tempo: singinig velocity in BPM (optional)
-- scale: By default major (optional)
+- file: the name of the wav file which is then reproduced with a loop or play method (Optional: Creates a file called "v1.wav" by default)
+- dur: specifies duration of each note (Optional: All notes take 1 BPM by default)
+- lyrics: Is a string which is then splitted by spaces and mapped to each note. (Optional: Just says "oooooo" by default)
+- sex: "female" or "male" (Optional, female by default)
 
 A demonstration video can be found [here](https://youtu.be/cgZuO78tVVE) (The command usage in the video is outdated, the interface is a little bit more simple now).
 
@@ -36,16 +35,16 @@ vrender(NOTES, file="v1", lyrics="o", dur=[1],sex="female")
 
 ```
 
-There might be more notes than words or specified durations, in that case those are extended repeating the string or list respectively.
+There might be more notes than specified words or durations, in that case those are extended repeating the string or list respectively.
 
 
 ### Example using all parameters
 ```
-from .Extensions.VRender import vrender
+from .Extensions.VRender import vrender # Import vrender
 
-vrender([0,2,0,4], file="wavName", lyrics="hey ho lets go", dur=[1,1,1,1],sex="male")
+vrender([0,2,0,4], file="wavName", lyrics="hey ho lets go", dur=[1,1,1,1],sex="male") # Generate voice audio file
 
-v1 >> loop('wavName',P[4:12],dur=1)
+v1 >> loop('wavName',P[4:12],dur=1) # Play it
 
 ```
 
@@ -59,3 +58,21 @@ vrender([3,2,1,0,4,4,4,4])
 v1 >> loop('v1',P[4:12],dur=1)
 
 ```
+
+If you play an audio sample, then overwrite the sample and try to play it again it will probably play the older one. To fix these you can use the command free, to clean the foxdot buffers.
+
+
+```
+from .Extensions.VRender import vrender
+
+vrender([3,2,1,0,4,4,4,4],name="v2")
+v2 >> loop('v2',P[4:12],dur=1)
+
+vrender([3,3,3,4],name="v2")
+Samples.free(int(v2.buf))
+v2 >> loop('v2',P[4:12],dur=1)
+
+
+```
+
+As you may note in the example, the loop command starts playing the audio in the fourth BPM (P[4:12]), it's because the audio is generated with an initial silence of 4 beats. It might be fixed in the future.

--- a/FoxDot/lib/Extensions/VRender/README.md
+++ b/FoxDot/lib/Extensions/VRender/README.md
@@ -28,14 +28,34 @@ The feature provides the method vrender which has the following parameters
 - tempo: singinig velocity in BPM (optional)
 - scale: By default major (optional)
 
-A demonstration video can be found [here](https://youtu.be/cgZuO78tVVE).
+A demonstration video can be found [here](https://youtu.be/cgZuO78tVVE) (The command usage in the video is outdated, the interface is a little bit more simple now).
 
-### Example
+### Command description, with default values
+```
+vrender(NOTES, file="v1", lyrics="o", dur=[1],sex="female")
+
+```
+
+There might be more notes than words or specified durations, in that case those are extended repeating the string or list respectively.
+
+
+### Example using all parameters
 ```
 from .Extensions.VRender import vrender
 
-vrender("wavName", lyrics="hey ho lets go", notes=[0,2,0,4], dur=[1,1,1,1],tempo=120,scale=Scale.minor)
+vrender([0,2,0,4], file="wavName", lyrics="hey ho lets go", dur=[1,1,1,1],sex="male")
+
+v1 >> loop('wavName',P[4:12],dur=1)
+
 ```
 
-### Posible problems
-Relative paths are hardcoded at ```FoxDot/FoxDot/lib/Extensions/VRender/constants.py```, they are specified assuming FoxDot is executed with the terminal running on the FoxDot folder (Where lib and snd folders are located), if some file can't be found you can try changing the relative paths for your absolute path to this folder.
+
+### Example using only the notes
+```
+from .Extensions.VRender import vrender
+
+vrender([3,2,1,0,4,4,4,4])
+
+v1 >> loop('v1',P[4:12],dur=1)
+
+```

--- a/FoxDot/lib/Extensions/VRender/VRender.py
+++ b/FoxDot/lib/Extensions/VRender/VRender.py
@@ -2,12 +2,23 @@ from __future__ import absolute_import, print_function
 
 import os
 
-from .Constants import *
 from .Composer import compose
 from .VoiceSpecificator import generateVoiceSpecification
 from .Sinsy import download
 
-def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex):
+
+def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex,local,foxdot_root):
+
+	# Constants
+	print(foxdot_root)
+	FILES_ROOT = os.path.realpath(foxdot_root + "/lib/Extensions/VRender/tmp/")
+	LAST_MIDI = FILES_ROOT + "/last_midi_generated_by_vrender.mid"
+	VOICE_XML_ORIGINAL=FILES_ROOT + "/last_voice.musicxml"
+	VOICE_XML_PROCESSED=FILES_ROOT+"/last_voice.xml"
+
+	WAVS_ROOT = os.path.realpath(foxdot_root + "/snd/_loop_/")
+	LAST_VOICE_WAV = WAVS_ROOT + "/last_voice_generated.wav"
+
 
 	print("Running voice renderization")
 
@@ -17,13 +28,15 @@ def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex):
 
 	generateVoiceSpecification(lyrics,tempo,VOICE_XML_ORIGINAL,VOICE_XML_PROCESSED)
 
-	urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=4' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
-	if sex == "male":
-		urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=5' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
+	if not local:
+		if sex == "male":
+			urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=5' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
+		else:
+			urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=4' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
 
-	download(urlfileName,LAST_VOICE_WAV)
+		download(urlfileName,LAST_VOICE_WAV)
 
-	os.system("cp " + LAST_VOICE_WAV + " " + WAVS_ROOT + outputName + ".wav")
+	os.system("cp " + LAST_VOICE_WAV + " " + WAVS_ROOT + "/" + outputName + ".wav")
 
 	print("Finished voice renderization")
 

--- a/FoxDot/lib/Extensions/VRender/VRender.py
+++ b/FoxDot/lib/Extensions/VRender/VRender.py
@@ -7,7 +7,7 @@ from .VoiceSpecificator import generateVoiceSpecification
 from .Sinsy import download
 
 
-def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex,local,foxdot_root):
+def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex,foxdot_root):
 
 	# Constants
 	print(foxdot_root)
@@ -28,13 +28,11 @@ def renderizeVoice(outputName,lyrics,notes,durations,tempo,scale,sex,local,foxdo
 
 	generateVoiceSpecification(lyrics,tempo,VOICE_XML_ORIGINAL,VOICE_XML_PROCESSED)
 
-	if not local:
-		if sex == "male":
-			urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=5' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
-		else:
-			urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=4' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
-
-		download(urlfileName,LAST_VOICE_WAV)
+	if sex == "male":
+		urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=5' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
+	else:
+		urlfileName = os.popen("curl -X POST -F 'SPKR_LANG=english' -F 'SPKR=4' -F 'SYNALPHA=0.55' -F 'VIBPOWER=1' -F 'F0SHIFT=0' -F  'SYNSRC=@" + VOICE_XML_PROCESSED +"' http://sinsy.sp.nitech.ac.jp/index.php | grep 'lf0'").read()
+	download(urlfileName,LAST_VOICE_WAV)
 
 	os.system("cp " + LAST_VOICE_WAV + " " + WAVS_ROOT + "/" + outputName + ".wav")
 

--- a/FoxDot/lib/Extensions/VRender/__init__.py
+++ b/FoxDot/lib/Extensions/VRender/__init__.py
@@ -4,8 +4,6 @@ from .VRender import renderizeVoice
 from ...SCLang import SynthDef
 from ... import Clock, Scale, Root
 from ...Settings import FOXDOT_ROOT
-#from ...Buffers import Samples
-
 
 class VRenderSynthDef(SynthDef):
     def __init__(self):
@@ -13,6 +11,7 @@ class VRenderSynthDef(SynthDef):
         self.add()
 
     def __call__(self, notes, pos=0, sample=0, **kwargs):
+
         if "lyrics" in kwargs:
             lyrics = kwargs['lyrics']
         else:
@@ -27,16 +26,14 @@ class VRenderSynthDef(SynthDef):
             filename = kwargs['file']
         else:
             filename = 'v1'
-#            print(Samples.getBufferFromSymbol('v1'))
-#            Samples.free(int(Samples.getBufferFromSymbol('v1')))
 
+        if "sex" in kwargs:
+            sex = kwargs["sex"]
+        else:
+            sex = "female"
 
         scale = list(Scale.default)
         tempo = int(Clock.bpm)
-
-        sex = "female"
-        if "sex" in kwargs:
-            sex = kwargs["sex"]
 
         notes = list(map(lambda x: x + Root.default,notes))
 

--- a/FoxDot/lib/Extensions/VRender/__init__.py
+++ b/FoxDot/lib/Extensions/VRender/__init__.py
@@ -1,43 +1,49 @@
 from __future__ import absolute_import, print_function
 
 from .VRender import renderizeVoice
-from ...SCLang import SampleSynthDef
-from ...Buffers import Samples
+from ...SCLang import SynthDef
+#from ...Buffers import Samples
+from ... import Clock, Scale, Root
+from ...Settings import FOXDOT_ROOT
 
-class VRenderSynthDef(SampleSynthDef):
+
+class VRenderSynthDef(SynthDef):
     def __init__(self):
-        SampleSynthDef.__init__(self, "vrender")
-        self.pos = self.new_attr_instance("pos")
-        self.sample = self.new_attr_instance("sample")
-        self.defaults['pos']   = 0
-        self.defaults['sample']   = 0
-        self.base.append("osc = PlayBuf.ar(2, buf, BufRateScale.kr(buf) * rate, startPos: BufSampleRate.kr(buf) * pos);")
-        self.base.append("osc = osc * EnvGen.ar(Env([0,1,1,0],[0.05, sus-0.05, 0.05]));")
-        self.osc = self.osc * self.amp
+        SynthDef.__init__(self, "vrender")
         self.add()
 
-    def __call__(self, filename, pos=0, sample=0, **kwargs):
-        lyrics = kwargs['lyrics']
-        durations = kwargs['dur']
-        notes = kwargs['notes']
+    def __call__(self, notes, pos=0, sample=0, **kwargs):
+        if "lyrics" in kwargs:
+            lyrics = kwargs['lyrics']
+        else:
+            lyrics = "oo "
 
-        scale = [0,2,4,5,7,9,11]
-        if "scale" in kwargs:
-            scale = list(kwargs["scale"])
+        if "dur" in kwargs:
+            durations = kwargs['dur']
+        else:
+            durations = [1]
 
-        tempo = 100
-        if "tempo" in kwargs:
-            tempo = kwargs["tempo"]
+        if 'file' in kwargs:
+            filename = kwargs['file']
+        else:
+            filename = 'v1'
+#            print(Samples.getBufferFromSymbol('v1'))
+#            Samples.free(int(Samples.getBufferFromSymbol('v1')))
+
+
+        scale = list(Scale.default)
+        tempo = int(Clock.bpm)
 
         sex = "female"
         if "sex" in kwargs:
             sex = kwargs["sex"]
 
-        renderizeVoice(filename,lyrics,notes,durations,tempo,scale,sex)
+        local = False
 
-#        kwargs = {"dur":sum(kwargs['dur'])}
+        print("root default",Root.default)
 
-#        kwargs["buf"] = Samples.loadBuffer(filename, sample)
-#        return SampleSynthDef.__call__(self, pos, **kwargs)
+        notes = list(map(lambda x: x + Root.default,notes))
+
+        renderizeVoice(filename,lyrics,notes,durations,tempo,scale,sex,local,FOXDOT_ROOT)
 
 vrender = VRenderSynthDef()

--- a/FoxDot/lib/Extensions/VRender/__init__.py
+++ b/FoxDot/lib/Extensions/VRender/__init__.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, print_function
 
 from .VRender import renderizeVoice
 from ...SCLang import SynthDef
-#from ...Buffers import Samples
 from ... import Clock, Scale, Root
 from ...Settings import FOXDOT_ROOT
+#from ...Buffers import Samples
 
 
 class VRenderSynthDef(SynthDef):
@@ -38,12 +38,8 @@ class VRenderSynthDef(SynthDef):
         if "sex" in kwargs:
             sex = kwargs["sex"]
 
-        local = False
-
-        print("root default",Root.default)
-
         notes = list(map(lambda x: x + Root.default,notes))
 
-        renderizeVoice(filename,lyrics,notes,durations,tempo,scale,sex,local,FOXDOT_ROOT)
+        renderizeVoice(filename,lyrics,notes,durations,tempo,scale,sex,FOXDOT_ROOT)
 
 vrender = VRenderSynthDef()

--- a/FoxDot/lib/Workspace/tmp/tempfile.txt
+++ b/FoxDot/lib/Workspace/tmp/tempfile.txt
@@ -1,0 +1,14 @@
+from .Extensions.VRender import vrender
+
+vrender([0,1,2,3], lyrics="oo ", dur=[1,1,1,1])
+
+
+a = Samples.getBufferFromSymbol('v1')
+
+print(int(a))
+
+print(int(v1.buf))
+
+v1 >> loop('v1',P[4:8],dur=1)
+
+print(Root.default)

--- a/FoxDot/osc/sceffects/bandPassFilter.scd
+++ b/FoxDot/osc/sceffects/bandPassFilter.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\bandPassFilter,
-{|bus, bpf, bpr, bpnoise, sus|
+{|bus, sus, bpr, bpnoise, bpf|
 var osc;
 osc = In.ar(bus, 2);
 bpnoise = bpnoise / sus;

--- a/FoxDot/osc/sceffects/coarse.scd
+++ b/FoxDot/osc/sceffects/coarse.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\coarse,
-{|bus, coarse, sus|
+{|bus, sus, coarse|
 var osc;
 osc = In.kr(bus, 1);
 osc = osc * LFPulse.ar(coarse / sus);

--- a/FoxDot/osc/sceffects/combDelay.scd
+++ b/FoxDot/osc/sceffects/combDelay.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\combDelay,
-{|bus, echo, beat_dur, echotime|
+{|bus, echotime, beat_dur, echo|
 var osc;
 osc = In.ar(bus, 2);
 osc = osc + CombL.ar(osc, delaytime: echo * beat_dur, maxdelaytime: 2 * beat_dur, decaytime: echotime * beat_dur);

--- a/FoxDot/osc/sceffects/filterSwell.scd
+++ b/FoxDot/osc/sceffects/filterSwell.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\filterSwell,
-{|bus, swell, sus, hpr|
+{|bus, hpr, swell, sus|
 var osc,env;
 osc = In.ar(bus, 2);
 env = EnvGen.kr(Env([0,1,0], times:[(sus*0.25), (sus*0.25)], curve:\sin));

--- a/FoxDot/osc/sceffects/glissando.scd
+++ b/FoxDot/osc/sceffects/glissando.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\glissando,
-{|bus, glide, glide_delay, sus|
+{|bus, sus, glide_delay, glide|
 var osc;
 osc = In.kr(bus, 1);
 osc = osc * EnvGen.ar(Env([1, 1, (1.059463**glide)], [sus*glide_delay, sus*(1-glide_delay)]));

--- a/FoxDot/osc/sceffects/highPassFilter.scd
+++ b/FoxDot/osc/sceffects/highPassFilter.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\highPassFilter,
-{|bus, hpf, hpr|
+{|bus, hpr, hpf|
 var osc;
 osc = In.ar(bus, 2);
 osc = RHPF.ar(osc, hpf, hpr);

--- a/FoxDot/osc/sceffects/pitchBend.scd
+++ b/FoxDot/osc/sceffects/pitchBend.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\pitchBend,
-{|bus, bend, sus, benddelay|
+{|bus, sus, bend, benddelay|
 var osc;
 osc = In.kr(bus, 1);
 osc = osc * EnvGen.ar(Env([1, 1, 1 + bend, 1], [sus * benddelay, (sus*(1-benddelay)/2), (sus*(1-benddelay)/2)]));

--- a/FoxDot/osc/sceffects/reverb.scd
+++ b/FoxDot/osc/sceffects/reverb.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\reverb,
-{|bus, room, mix|
+{|bus, mix, room|
 var osc;
 osc = In.ar(bus, 2);
 osc = FreeVerb.ar(osc, mix, room);

--- a/FoxDot/osc/sceffects/slideFrom.scd
+++ b/FoxDot/osc/sceffects/slideFrom.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\slideFrom,
-{|bus, slidefrom, sus, slidedelay|
+{|bus, slidedelay, sus, slidefrom|
 var osc;
 osc = In.kr(bus, 1);
 osc = osc * EnvGen.ar(Env([slidefrom + 1, slidefrom + 1, 1], [sus*slidedelay, sus*(1-slidedelay)]));

--- a/FoxDot/osc/sceffects/spinPan.scd
+++ b/FoxDot/osc/sceffects/spinPan.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\spinPan,
-{|bus, spin, sus|
+{|bus, sus, spin|
 var osc;
 osc = In.ar(bus, 2);
 osc = osc * [FSinOsc.ar(spin / 2, iphase: 1, mul: 0.5, add: 0.5), FSinOsc.ar(spin / 2, iphase: 3, mul: 0.5, add: 0.5)];

--- a/FoxDot/osc/sceffects/striate.scd
+++ b/FoxDot/osc/sceffects/striate.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\striate,
-{|bus, striate, sus, buf, rate|
+{|bus, buf, rate, sus, striate|
 var osc;
 osc = In.kr(bus, 1);
 osc = osc * LFPulse.ar(striate / sus, width:  (BufDur.kr(buf) / rate) / sus);

--- a/FoxDot/osc/scsyndef/arpy.scd
+++ b/FoxDot/osc/scsyndef/arpy.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\arpy,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -8,7 +8,7 @@ freq=(freq / 2);
 amp=(amp * 2);
 freq=(freq + [0, 0.5]);
 osc=LPF.ar(Impulse.ar(freq), 3000);
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: (sus * 0.25),level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: (sus * 0.25)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/audioin.scd
+++ b/FoxDot/osc/scsyndef/audioin.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\audioin,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=AudioIn.ar(1);
-env=EnvGen.ar(Env(times: [0.01, (sus - 0.01), 0.01],levels: [0, 1, 1, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, 1, 1, 0],curve: 'lin',times: [0.01, (sus - 0.01), 0.01]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/bass.scd
+++ b/FoxDot/osc/scsyndef/bass.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\bass,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=8, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=8, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq / 4);
 amp=(amp * 0.8);
 osc=((LFTri.ar(freq, mul: amp) + VarSaw.ar(freq, width: (rate / 10), mul: amp)) + SinOscFB.ar(freq, mul: (amp / 2)));
-env=EnvGen.ar(Env.perc(attackTime: 0.02,releaseTime: sus,level: amp,curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 'lin',attackTime: 0.02,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/bell.scd
+++ b/FoxDot/osc/scsyndef/bell.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\bell,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, verb=0.5, room=0.5|
+{|vib=0, rel=0.01, bus=0, rate=1, verb=0.5, peak=1, amp=1, freq=0, beat_dur=1, room=0.5, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/blip.scd
+++ b/FoxDot/osc/scsyndef/blip.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\blip,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/bug.scd
+++ b/FoxDot/osc/scsyndef/bug.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\bug,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=1, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 amp=(amp / 5);
 freq=(freq * [1, 1.0001]);
 osc=(Pulse.ar(freq, width: [0.09, 0.16, 0.25]) * SinOsc.ar((rate * 4)));
-env=EnvGen.ar(Env.perc(attackTime: (sus * 1.5),releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: (sus * 1.5),releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/charm.scd
+++ b/FoxDot/osc/scsyndef/charm.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\charm,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -8,7 +8,7 @@ freq=(freq + [0, 2]);
 freq=(freq * [1, 2]);
 osc=(SinOsc.ar(freq, mul: (amp / 4)) + VarSaw.ar((freq * 8), 10, mul: (amp / 8)));
 osc=LPF.ar(osc, SinOsc.ar(Line.ar(1, (rate * 4), (sus / 8)), 0, (freq * 2), ((freq * 2) + 10)));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/creep.scd
+++ b/FoxDot/osc/scsyndef/creep.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\creep,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 amp=(amp / 4);
 osc=PMOsc.ar(freq, (freq * 2), 10);
-env=EnvGen.ar(Env(times: [sus, 0.001],levels: [0.0001, amp, 0],curve: 'exp'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0.0001, amp, 0],curve: 'exp',times: [sus, 0.001]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/crunch.scd
+++ b/FoxDot/osc/scsyndef/crunch.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\crunch,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 amp=(amp * 0.5);
 osc=LFNoise0.ar(((Crackle.kr(1.95) * freq) * 15), mul: amp);
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: 0.1,level: (amp / 4),curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: (amp / 4),curve: 0,attackTime: 0.01,releaseTime: 0.1), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/dab.scd
+++ b/FoxDot/osc/scsyndef/dab.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\dab,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
-osc=(HPF.ar(Saw.ar((freq / 4), mul: (amp / 2)), 2000) + VarSaw.ar((freq / 4), mul: amp, width: EnvGen.ar(Env.perc(attackTime: (sus / 20),releaseTime: (sus / 4),level: 0.5,curve: -5), doneAction: 0)));
-env=EnvGen.ar(Env(times: [(sus * 0.25), (sus * 1)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+osc=(HPF.ar(Saw.ar((freq / 4), mul: (amp / 2)), 2000) + VarSaw.ar((freq / 4), mul: amp, width: EnvGen.ar(Env.perc(level: 0.5,curve: -5,attackTime: (sus / 20),releaseTime: (sus / 4)), doneAction: 0)));
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(sus * 0.25), (sus * 1)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/dirt.scd
+++ b/FoxDot/osc/scsyndef/dirt.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\dirt,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq / 4);
 amp=(amp / 2);
 osc=((LFSaw.ar(freq, mul: amp) + VarSaw.ar((freq + 1), width: 0.85, mul: amp)) + SinOscFB.ar((freq - 1), mul: (amp / 2)));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/donk.scd
+++ b/FoxDot/osc/scsyndef/donk.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\donk,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/dub.scd
+++ b/FoxDot/osc/scsyndef/dub.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\dub,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/feel.scd
+++ b/FoxDot/osc/scsyndef/feel.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\feel,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -8,7 +8,7 @@ sus=(sus * 1.5);
 amp=(amp / 3);
 freq=(freq * [1, 1.005]);
 osc=Klank.ar(`[[1, 2, 3, (3 + ((rate - 1) / 10))], [1, 1, 1, 1], [2, 2, 2, 2]], (Impulse.ar(0.0005) * Saw.ar(freq, add: 1)), freq);
-env=EnvGen.ar(Env(times: (sus * 2),levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: (sus * 2)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/fuzz.scd
+++ b/FoxDot/osc/scsyndef/fuzz.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\fuzz,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq / 2);
 amp=(amp / 6);
 osc=LFSaw.ar(LFSaw.kr(freq, 0, freq, (freq * 2)));
-env=EnvGen.ar(Env(times: [(sus * 0.8), 0.01],levels: [(amp * 1), (amp * 1), (amp * 0.01)],curve: 'step'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [(amp * 1), (amp * 1), (amp * 0.01)],curve: 'step',times: [(sus * 0.8), 0.01]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/glass.scd
+++ b/FoxDot/osc/scsyndef/glass.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\glass,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,8 +7,8 @@ freq = [freq, freq+fmod];
 sus=(sus * 1.5);
 amp=(amp * 1.5);
 freq=(freq * [1, (1 + (0.005 * rate))]);
-osc=Klank.ar(`[[2, 4, 9, 16], [1, 1, 1, 1], [2, 2, 2, 2]], (PinkNoise.ar(0.0005).dup * SinOsc.ar((freq / 4), add: 1, mul: 0.5)), freq);
-env=EnvGen.ar(Env(times: (sus * 2),levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+osc=Klank.ar(`[[2, 4, 9, 16], [1, 1, 1, 1], [2, 2, 2, 2]], (PinkNoise.ar(0.0005).dup * SinOsc.ar((freq / 4), mul: 0.5, add: 1)), freq);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: (sus * 2)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/gong.scd
+++ b/FoxDot/osc/scsyndef/gong.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\gong,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/growl.scd
+++ b/FoxDot/osc/scsyndef/growl.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\growl,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 sus=(sus * 1.5);
-osc=(SinOsc.ar((freq + SinOsc.kr(0.5, add: 1, mul: 2)), mul: amp) * Saw.ar(((sus / 1.5) * 32)));
-env=EnvGen.ar(Env(times: [(sus / 2), (sus / 2)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+osc=(SinOsc.ar((freq + SinOsc.kr(0.5, mul: 2, add: 1)), mul: amp) * Saw.ar(((sus / 1.5) * 32)));
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(sus / 2), (sus / 2)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/jbass.scd
+++ b/FoxDot/osc/scsyndef/jbass.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\jbass,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/karp.scd
+++ b/FoxDot/osc/scsyndef/karp.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\karp,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -9,7 +9,7 @@ osc=LFNoise0.ar((400 + (400 * rate)), amp);
 osc=(osc * XLine.ar(1, 1e-06, (sus * 0.1)));
 freq=((265 / (freq * 0.666)) * 0.005);
 osc=CombL.ar(osc, delaytime: freq, maxdelaytime: 2);
-env=EnvGen.ar(Env(times: [sus],levels: [(amp * 1), (amp * 1)],curve: 'step'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [(amp * 1), (amp * 1)],curve: 'step',times: [sus]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/klank.scd
+++ b/FoxDot/osc/scsyndef/klank.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\klank,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 sus=(sus * 1.5);
 osc=Klank.ar(`[[1, 2, 3, 4], [1, 1, 1, 1], [2, 2, 2, 2]], ClipNoise.ar(0.0005).dup, freq);
-env=EnvGen.ar(Env(times: (sus * 2),levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: (sus * 2)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/lazer.scd
+++ b/FoxDot/osc/scsyndef/lazer.scd
@@ -1,13 +1,13 @@
 SynthDef.new(\lazer,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 freq=(freq * [1, 1.005]);
 amp=(amp * 0.1);
-osc=(VarSaw.ar(freq, width: ((rate - 1) / 4)) + LFSaw.ar(LFNoise0.ar((rate * 20), add: (freq * Pulse.ar(((rate - 2) + 0.1), add: 1)), mul: 0.5)));
-env=EnvGen.ar(Env.perc(attackTime: 0.1,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+osc=(VarSaw.ar(freq, width: ((rate - 1) / 4)) + LFSaw.ar(LFNoise0.ar((rate * 20), mul: 0.5, add: (freq * Pulse.ar(((rate - 2) + 0.1), add: 1)))));
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.1,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/loop.scd
+++ b/FoxDot/osc/scsyndef/loop.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\loop,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1.0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, buf=0, pos=0, room=0.1, sample=0|
+{|vib=0, rel=0.01, bus=0, pos=0, sample=0, rate=1.0, peak=1, amp=1, freq=0, buf=0, beat_dur=1, room=0.1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 rate = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/marimba.scd
+++ b/FoxDot/osc/scsyndef/marimba.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\marimba,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=Klank.ar(`[[0.5, 1, 4, 9], [0.5, 1, 1, 1], [1, 1, 1, 1]], PinkNoise.ar([0.007, 0.007]), freq, [0, 2]);
 sus=1;
-env=EnvGen.ar(Env.perc(attackTime: 0.001,releaseTime: sus,level: amp,curve: -6), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: -6,attackTime: 0.001,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/noise.scd
+++ b/FoxDot/osc/scsyndef/noise.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\noise,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 freq=(freq * 2);
 osc=LFNoise0.ar(freq, amp);
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/nylon.scd
+++ b/FoxDot/osc/scsyndef/nylon.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\nylon,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=(LFPulse.ar(freq, 0.5, (0.33 * rate), 0.25) + LFPar.ar((freq + 0.5), 1, 0.1, 0.25));
-env=EnvGen.ar(Env.perc(attackTime: 0.000125,releaseTime: (sus * 3),level: amp,curve: -4), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: -4,attackTime: 0.000125,releaseTime: (sus * 3)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/orient.scd
+++ b/FoxDot/osc/scsyndef/orient.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\orient,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, room=10, verb=0.7|
+{|vib=0, rel=0.01, bus=0, rate=0, verb=0.7, peak=1, amp=1, freq=0, beat_dur=1, room=10, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=(LFPulse.ar(freq, 0.5, 0.25, 0.25) + LFPulse.ar(freq, 1, 0.1, 0.25));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/play1.scd
+++ b/FoxDot/osc/scsyndef/play1.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\play1,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1.0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, buf=0, pos=0, room=0.1|
+{|vib=0, rel=0.01, bus=0, pos=0, rate=1.0, peak=1, amp=1, freq=0, buf=0, beat_dur=1, room=0.1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 rate = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/play2.scd
+++ b/FoxDot/osc/scsyndef/play2.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\play2,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1.0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, buf=0, pos=0, room=0.1|
+{|vib=0, rel=0.01, bus=0, pos=0, rate=1.0, peak=1, amp=1, freq=0, buf=0, beat_dur=1, room=0.1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 rate = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/pluck.scd
+++ b/FoxDot/osc/scsyndef/pluck.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\pluck,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/pulse.scd
+++ b/FoxDot/osc/scsyndef/pulse.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\pulse,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 amp=(amp / 8);
 osc=Pulse.ar(freq);
 osc=(osc * amp);
-env=EnvGen.ar(Env(times: [0.01, (sus - 0.01), 0.01],levels: [0, 1, 1, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, 1, 1, 0],curve: 'lin',times: [0.01, (sus - 0.01), 0.01]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/quin.scd
+++ b/FoxDot/osc/scsyndef/quin.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\quin,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq * [1, 1.01]);
 osc=(Klank.ar(`[[1, 2, 4, 2], [100, 50, 0, 10], [1, 5, 0, 1]], Impulse.ar(freq).dup, freq) / 5000);
 osc=(osc * LFSaw.ar((freq * (1 + rate))));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 1), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 1,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/rave.scd
+++ b/FoxDot/osc/scsyndef/rave.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\rave,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=Gendy1.ar((rate - 1), mul: (amp / 2), minfreq: freq, maxfreq: (freq * 2));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/razz.scd
+++ b/FoxDot/osc/scsyndef/razz.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\razz,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0.3, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0.3, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -9,7 +9,7 @@ rate=Lag.ar(K2A.ar(freq), rate);
 osc=(Saw.ar((rate * [1, 0.5]), [1, 0.3333333333333333]) + Saw.ar((rate + LFNoise2.ar(4).range(0.5, 2.5)), 1));
 osc=BPF.ar(osc, (freq * 2.5), 0.3);
 osc=RLPF.ar(osc, 1300, 0.78);
-env=EnvGen.ar(Env.perc(attackTime: 0.125,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.125,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/ripple.scd
+++ b/FoxDot/osc/scsyndef/ripple.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\ripple,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 amp=(amp / 6);
 osc=(Pulse.ar((freq / 4), 0.2, 0.25) + Pulse.ar((freq + 1), 0.5, 0.5));
 osc=(osc * SinOsc.ar((rate / sus), 0, 0.5, 1));
-env=EnvGen.ar(Env(times: [(0.55 * sus), (0.55 * sus)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(0.55 * sus), (0.55 * sus)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/saw.scd
+++ b/FoxDot/osc/scsyndef/saw.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\saw,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 amp=(amp / 8);
 osc=Saw.ar(freq);
 osc=(osc * amp);
-env=EnvGen.ar(Env(times: [0.01, (sus - 0.01), 0.01],levels: [0, 1, 1, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, 1, 1, 0],curve: 'lin',times: [0.01, (sus - 0.01), 0.01]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/scatter.scd
+++ b/FoxDot/osc/scsyndef/scatter.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\scatter,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=((Saw.ar(freq, mul: (amp / 8)) + VarSaw.ar((freq + [2, 1]), mul: (amp / 8))) * LFNoise0.ar(rate));
-env=EnvGen.ar(Env.linen(attackTime: 0.01,releaseTime: (sus / 2),level: (sus / 2),curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.linen(level: (sus / 2),curve: 0,attackTime: 0.01,releaseTime: (sus / 2)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/scratch.scd
+++ b/FoxDot/osc/scsyndef/scratch.scd
@@ -1,13 +1,13 @@
 SynthDef.new(\scratch,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0.04, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, depth=0.5|
+{|vib=0, rel=0.01, bus=0, rate=0.04, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, depth=0.5, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 amp=(amp / 4);
 freq=(freq * Crackle.ar(1.5));
-osc=SinOsc.ar(Vibrato.kr(freq, 2, 3, rateVariation: rate, depthVariation: depth), mul: amp);
-env=EnvGen.ar(Env(times: [(sus / 2), (sus / 2)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+osc=SinOsc.ar(Vibrato.kr(freq, 2, 3, depthVariation: depth, rateVariation: rate), mul: amp);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(sus / 2), (sus / 2)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/sitar.scd
+++ b/FoxDot/osc/scsyndef/sitar.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\sitar,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -10,7 +10,7 @@ osc=LFNoise0.ar([8400, 8500], amp);
 osc=(osc * XLine.ar(1, 1e-06, (sus * 0.1)));
 freq=((265 / (freq * [0.666, 0.669])) * 0.005);
 osc=CombL.ar(osc, delaytime: freq, maxdelaytime: 2);
-env=EnvGen.ar(Env(times: [sus],levels: [(amp * 1), (amp * 1)],curve: 'step'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [(amp * 1), (amp * 1)],curve: 'step',times: [sus]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/snick.scd
+++ b/FoxDot/osc/scsyndef/snick.scd
@@ -1,11 +1,11 @@
 SynthDef.new(\snick,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 osc=(LFPar.ar(freq, mul: 1) * Blip.ar(((rate + 1) * 4)));
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/soft.scd
+++ b/FoxDot/osc/scsyndef/soft.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\soft,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq / 2);
 amp=(amp / (200 * (1 + rate)));
 osc=Klank.ar(`[[7, 5, 3, 1], [8, 4, 2, 1], [2, 4, 8, 16]], LFNoise0.ar((rate / sus)), freq);
-env=EnvGen.ar(Env(times: sus,levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/soprano.scd
+++ b/FoxDot/osc/scsyndef/soprano.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\soprano,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -8,7 +8,7 @@ sus=(sus * 1.75);
 amp=(amp / 2);
 freq=Vibrato.kr(freq, (rate + 4));
 osc=(SinOsc.ar((freq * 3), mul: amp) + SinOscFB.ar((freq * 3), mul: (amp / 2)));
-env=EnvGen.ar(Env(times: [(sus / 2), (sus / 2)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(sus / 2), (sus / 2)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/spark.scd
+++ b/FoxDot/osc/scsyndef/spark.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\spark,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/squish.scd
+++ b/FoxDot/osc/scsyndef/squish.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\squish,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/star.scd
+++ b/FoxDot/osc/scsyndef/star.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\star,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);

--- a/FoxDot/osc/scsyndef/swell.scd
+++ b/FoxDot/osc/scsyndef/swell.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\swell,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=1, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,8 +7,8 @@ freq = [freq, freq+fmod];
 amp=(amp / 4);
 freq=(freq + [0, 1]);
 freq=(freq * [1, 0.5]);
-osc=VarSaw.ar(freq, width: SinOsc.ar((rate / ((2 * sus) / 1.25)), add: 0.5, mul: [0.5, 0.5]), mul: [1, 0.5]);
-env=EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0);
+osc=VarSaw.ar(freq, width: SinOsc.ar((rate / ((2 * sus) / 1.25)), mul: [0.5, 0.5], add: 0.5), mul: [1, 0.5]);
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/twang.scd
+++ b/FoxDot/osc/scsyndef/twang.scd
@@ -1,5 +1,5 @@
 SynthDef.new(\twang,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
@@ -7,7 +7,7 @@ freq = [freq, freq+fmod];
 freq=(freq / 8);
 freq=(freq + [0, 2]);
 osc=LPF.ar(Impulse.ar(freq, 0.1), 4000);
-osc=(EnvGen.ar(Env.perc(attackTime: 0.01,releaseTime: sus,level: amp,curve: 0), doneAction: 0) * CombL.ar(osc, delaytime: (rate / (freq * 8)), maxdelaytime: 0.25));
+osc=(EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: 0.01,releaseTime: sus), doneAction: 0) * CombL.ar(osc, delaytime: (rate / (freq * 8)), maxdelaytime: 0.25));
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);
 	ReplaceOut.ar(bus, osc)}).add;

--- a/FoxDot/osc/scsyndef/varsaw.scd
+++ b/FoxDot/osc/scsyndef/varsaw.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\varsaw,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 freq=(freq * [1, 1.005]);
 osc=VarSaw.ar(freq, mul: (amp / 4), width: rate);
-env=EnvGen.ar(Env(times: [(sus / 2), (sus / 2)],levels: [0, amp, 0],curve: 'lin'), doneAction: 0);
+env=EnvGen.ar(Env(levels: [0, amp, 0],curve: 'lin',times: [(sus / 2), (sus / 2)]), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/viola.scd
+++ b/FoxDot/osc/scsyndef/viola.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\viola,
-{|amp=1, sus=1, pan=0, freq=0, vib=6, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, verb=0.33|
+{|vib=6, rel=0.01, bus=0, rate=0, verb=0.33, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 amp=(amp / 2);
-osc=PMOsc.ar(freq, Vibrato.kr(freq, rate: vib, depth: 0.008, delay: (sus * 0.25)), 10, mul: (amp / 2));
-env=EnvGen.ar(Env.perc(attackTime: (0.25 * sus),releaseTime: (0.75 * sus),level: amp,curve: 0), doneAction: 0);
+osc=PMOsc.ar(freq, Vibrato.kr(freq, delay: (sus * 0.25), rate: vib, depth: 0.008), 10, mul: (amp / 2));
+env=EnvGen.ar(Env.perc(level: amp,curve: 0,attackTime: (0.25 * sus),releaseTime: (0.75 * sus)), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);

--- a/FoxDot/osc/scsyndef/vrender.scd
+++ b/FoxDot/osc/scsyndef/vrender.scd
@@ -1,11 +1,9 @@
 SynthDef.new(\vrender,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=1.0, bus=0, blur=1, beat_dur=1, buf=0, pos=0, room=0.1, sample=0|
+{|vib=0, rel=0.01, bus=0, rate=0, peak=1, amp=1, freq=0, beat_dur=1, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
-rate = In.kr(bus, 1);
-osc = PlayBuf.ar(2, buf, BufRateScale.kr(buf) * rate, startPos: BufSampleRate.kr(buf) * pos);
-osc = osc * EnvGen.ar(Env([0,1,1,0],[0.05, sus-0.05, 0.05]));
-osc=(osc * amp);
+freq = In.kr(bus, 1);
+freq = [freq, freq+fmod];
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);
 	ReplaceOut.ar(bus, osc)}).add;

--- a/FoxDot/osc/scsyndef/zap.scd
+++ b/FoxDot/osc/scsyndef/zap.scd
@@ -1,12 +1,12 @@
 SynthDef.new(\zap,
-{|amp=1, sus=1, pan=0, freq=0, vib=0, fmod=0, rate=0, bus=0, blur=1, beat_dur=1, atk=0.01, decay=0.01, rel=0.01, peak=1, level=0.8, room=0, verb=0|
+{|vib=0, rel=0.01, bus=0, rate=0, verb=0, peak=1, amp=1, freq=0, beat_dur=1, room=0, decay=0.01, level=0.8, atk=0.01, sus=1, fmod=0, blur=1, pan=0|
 var osc, env;
 sus = sus * blur;
 freq = In.kr(bus, 1);
 freq = [freq, freq+fmod];
 amp=(amp / 10);
 osc=(Saw.ar(((freq * [1, 1.01]) + LFNoise2.ar(50).range(-2, 2))) + VarSaw.ar((freq + LFNoise2.ar(50).range(-2, 2)), 1));
-env=EnvGen.ar(Env.perc(attackTime: 0.025,releaseTime: sus,level: amp,curve: -10), doneAction: 0);
+env=EnvGen.ar(Env.perc(level: amp,curve: -10,attackTime: 0.025,releaseTime: sus), doneAction: 0);
 osc=(osc * env);
 osc = Mix(osc) * 0.5;
 osc = Pan2.ar(osc, pan);


### PR DESCRIPTION
- FOXDOT_ROOT constant is used to avoid absolute path problems.
- BPM and default scale is inferred from Clock.bpm, Scale.default without the need to pass it as a parameter.
- Root.default is used to adjust scales when root note is not C.