### PR TITLE
Update Players.py

### DIFF
--- a/FoxDot/lib/Players.py
+++ b/FoxDot/lib/Players.py
@@ -1515,7 +1515,7 @@ class Player(Repeatable):
 
                 if len(event['sus']) > 1:
 
-                    min_sus = min(event['sus'])
+                    min_sus = min(event['sus']) if min(event['sus']) else 1
 
                     offset = PGroup([(sus / min_sus) for sus in event["sus"]])
 


### PR DESCRIPTION
Avoid division by zero in the case of a "dur" tuple containing a 0
eg : bl >> blip(dur=(0,1))