### PR TITLE
Minor corrections to the tutorials:

### DIFF
--- a/FoxDot/demo/00_intro.py
+++ b/FoxDot/demo/00_intro.py
@@ -3,7 +3,7 @@
 ################
 # Executing code
 
-# To execute code in FoxDot, make sure your text cursor is in the ‘block’ of code
+# To execute code in FoxDot, make sure your text cursor is in the 'block' of code
 # (sections of text not separated by blank lines) and press Ctrl+Return
 
 # To execute just a single line, even in a block, press Alt+Return
@@ -15,7 +15,7 @@ print("Hello World")
 ##############
 # Help
 
-# If you’re ever stuck, or want to know more about a function or class
+# If you're ever stuck, or want to know more about a function or class
 # just type help followed by the name of that Python object in brackets:
 
 help(object)

--- a/FoxDot/demo/01_playing_notes.py
+++ b/FoxDot/demo/01_playing_notes.py
@@ -44,10 +44,10 @@ p1 >> pluck([0,0,0], dur=[1,2,3])
 # Or amplitude, the "volume" of each note
 p1 >> pluck([0,0,0], amp=[1,2,3])
 
-# If the second list, the amp in this example, is too long, then the first list, the degree, just loops 1 for each of the other list.
+# If the second list, the amp in this example, is too long, then the first list (the degree) just loops, and are matched with the remaining elements from the second list (the amplitude).
 p1 >> pluck([0,2,4], amp=[1,2,3,1,5])
 
-# More clearly, all the lists, just advance by one regardless of length.
+# More generally, all the lists are traversed regardless of their length.
 p1 >> pluck([0,2,4], dur=[1,2], amp=[1,2,3,1,5])
 
 # Arguments can be integers, floating points, fractions, lists,
@@ -95,7 +95,7 @@ p1 >> pluck([0, 2, 3, 4], dur=1/2)
 p2 >> pads([(0, 2, 4), (3, 5, 7)], dur=8)
 
 # Play only this player, muting others
-p1.solo() # defaults to 1
+p1.solo() # default value is 1 (solo on)
 
 # And turn the solo off
 p1.solo(0)

--- a/FoxDot/demo/02_algorithmic_manipulation.py
+++ b/FoxDot/demo/02_algorithmic_manipulation.py
@@ -4,7 +4,7 @@
 p1 >> pads([0,1,2,3])
 
 # It's possible to manipulate this by adding an array of numbers to the Player object
-# This raises the 4 note played by 2 degrees
+# This raises the 4th note played by 2 degrees
 p1 >> pads([0,1,2,3]) + [0,0,0,2]
 
 # And this raises every third note by 2

--- a/FoxDot/demo/03_playing_samples.py
+++ b/FoxDot/demo/03_playing_samples.py
@@ -50,6 +50,7 @@ d1 >> play("x-o{-=[--][-o]}")
 
 # Angle brackets combine patterns to be play simultaneously
 d1 >> play("<X   ><-   ><#   ><V   >")
+
 d1 >> play("<X   >< -  ><  # ><   V>")
 
 # Each character is mapped to a folder of sound files and you can select different

--- a/FoxDot/demo/04_using_patterns.py
+++ b/FoxDot/demo/04_using_patterns.py
@@ -2,14 +2,14 @@
 
 
 # Player Objects use Python lists, known more commonly as arrays in other languages,
-# to sequence themselves. You’ve already used these previously, but they aren’t exactly
+# to sequence themselves. You've already used these previously, but they aren't exactly
 # flexible for manipulation. For example, try multiplying a list by two like so:
 
 print([1, 2, 3] * 2)
 
 # Is the result what you expected?
 
-# FoxDot uses a container type called a ‘Pattern’ to help solve this problem.
+# FoxDot uses a container type called a 'Pattern' to help solve this problem.
 # They act like regular lists but any mathematical operation performed on it is done to each item
 # in the list and done so pair-wise if using a second pattern. A basic pattern is created as
 # you would with a normal list or tuple, but with a 'P' preceeding it.
@@ -33,12 +33,13 @@ print(P[2:15:3])
 # Try some other mathematical operators and see what results you get.
 print(P[1,2,3] * (1,2))
 
-# Pattern objects also automatically lace any nested lists
-
+# Pattern objects also automatically interlace any nested list.
+# Compare
 # Normal list:
 for n in [0,1,2,[3,4],5]:
     print(n)
 
+# with
 # Pattern
 for n in P[0,1,2,[3,4],5]:
     print(n)
@@ -48,7 +49,10 @@ for n in P[0,1,2,[3,4],5]:
 for n in P[0,1,2,(3,4)]:
     print(n)
 
+# This is a PGroup:
 print(P(0,2,4) + 2)
+
+print(type(P(0,2,4) + 2))
 
 # In Python, you can generate a range of integers with the syntax range(start, stop, step).
 # By default, start is 0 and step is 1.
@@ -68,7 +72,7 @@ print(PRange(10) + [0,10])
 # To concatonate Patterns, use the pipe operator like so:
 print(PRange(10) | [0,10])
 # FoxDot automatically converts any object being piped to a Pattern to the base Pattern class
-# so you don’t have to worry about making sure everything is the right type.
+# so you don't have to worry about making sure everything is the right type.
 
 # Plays all the values together
 p1 >> pluck(P(4,6,8))

--- a/FoxDot/demo/05_player_attributes.py
+++ b/FoxDot/demo/05_player_attributes.py
@@ -10,7 +10,7 @@ print(harmony)
 p1 >> pluck(pitches)
 p2 >> star(harmony)
 
-# If you set the duration, of the second, it might not have the desired effect
+# If you set the duration of the second, it might not have the desired effect
 p1 >> pluck(pitches)
 p2 >> star(harmony, dur=1/2)
 

--- a/FoxDot/demo/09_groups.py
+++ b/FoxDot/demo/09_groups.py
@@ -20,7 +20,7 @@ p2.stop()
 p3.stop()
 
 # You can reference all the members with similar names
-p_all.dur = [1/2,1/4]
+p_all.dur = [1/2,1/4] # Run this while p1, p2... are playing!
 
 # or
 p_all.amplify=1
@@ -29,7 +29,7 @@ p_all.amplify=1
 p_all.stop()
 
 # Or...
-P_all.solo()
+p_all.solo()
 
 # To reduce the amount of typing, Player Objects can be grouped together and their attributes modified in a simpler way:
 p1 >> pads([0,2,4,2])
@@ -47,7 +47,7 @@ g1.amp=var([1,0],4)
 
 g1.stop()
 
-# You can use functions to group things together. To execute CMD+Return, not ALT+Return. 
+# You can use functions to group things together. To execute use CTRL+Return, not ALT+Return.
 def tune():
     b1 >> bass([0,3], dur=4)
     p1 >> pluck([0,4], dur=1/2)

--- a/FoxDot/demo/10_using_vars.py
+++ b/FoxDot/demo/10_using_vars.py
@@ -1,14 +1,14 @@
 # Tutorial 10: Using Vars
 
 
-# A TimeVar is an abbreviation of “Time Dependent Variable” and is a key feature of FoxDot.
+# A TimeVar is an abbreviation of "Time Dependent Variable" and is a key feature of FoxDot.
 # A TimeVar has a series of values that it changes between after a pre-defined number of beats
 # and is created using a var object with the syntax var([list_of_values],[list_of_durations]).
 
 # Generates the pattern: 0,0,0,0,3,3,3,3...
 a = var([0,3],4)            # Duration can be single value
 print(int(Clock.now()), a)   # 'a' initally has a value of 0
-# >>> 0, 0
+# >>> 0, 0                  # The first value may differ...
 
 print(int(Clock.now()), a)   # After 4 beats, the value changes to 3
 # >>> 4, 3
@@ -53,7 +53,7 @@ a.update([1,4], 8)
 
 print(int(Clock.now()), (a, b))
 
-# Vars can be nammed ...
+# Vars can be named ...
 var.chords = var([0,4,5,4],4)
 
 # And used later
@@ -91,7 +91,7 @@ print(x) # Keep pressing - it will eventually stop at 3
 ######################
 # Other types of "var"
 
-# There are several sub-classes of "var" that return values between 
+# There are several sub-classes of "var" that return values between
 # the numbers specified. For example a "linvar" gradually change
 # values in a linear fashion:
 

--- a/FoxDot/demo/13_advanced_clock.py
+++ b/FoxDot/demo/13_advanced_clock.py
@@ -1,8 +1,8 @@
 # Tutorial 13: Advanced Clock
 
-# Note: You don't need to run this line, its used for installing FoxDot for Linux users using Python 2.
-
-from __future__ import print_function 
+# Note: You don't need to run this line if you're using Python 3,
+# it's used for installing FoxDot for Linux users using Python 2.
+from __future__ import print_function
 
 # To see what is scheduled to be played.
 print(Clock)
@@ -13,14 +13,14 @@ print(Clock.latency)
 # The clock can schedule anything with a __call__ method using
 # It takes an absolute time clue to schedule a functions
 # Clock.schedule needs to know the beat to call something on
-Clock.schedule()
+Clock.schedule()   # raises TypeError
 
 # Schedule an event after a certain durations
 # Clock.future needs to know how many beats ahead to call something
-Clock.future()
+Clock.future()     # raises TypeError
 
-# These are equivilent
-Clock.schedule(Clock.now() + 4, lambda: print("hello"))
+# These are equivalent
+Clock.schedule(lambda: print("hello"), Clock.now() + 4)
 Clock.future(4, lambda: print("hello"))
 
 # To schedule something else
@@ -30,7 +30,7 @@ Clock.schedule(lambda: print("hello "))
 Clock.every(4, lambda: print("hello"))
 
 # Get the current clock and add 2.  Useful for scheduling.
-Clock.now() + 2
+print(Clock.now() + 2)
 
 # Issue command on the next bar
 nextBar(Clock.clear)

--- a/FoxDot/demo/14_player_attributes_reference.py
+++ b/FoxDot/demo/14_player_attributes_reference.py
@@ -21,8 +21,6 @@ d1 >> dirt([0,4,2,1], dur=1/2, hpf=4000)
 # This sets the high pass filter to 4000 Hz so only frequences in the audio
 # signal *above* that are actually heard. Let's change the resonance value. It's
 # default value is 1, so let's make it smaller
-d1 >> dirt([0,4,2,1], dur=1/2, hpf=4000)
-
 d1 >> dirt([0,4,2,1], dur=1/2, hpf=4000, hpr=0.3)
 
 
@@ -54,7 +52,7 @@ d1 >> play("*", dur=1/2, amp=[1,0,1,1,0])
 
 
 ####################
-# amplify - Chagnes amp, by multiplying agasint the existing value (instead of overwritting)
+# amplify - Changes amp, by multiplying agasint the existing value (instead of overwritting)
 
 # Creating a pattern with amp
 d1 >> play("*", dur=1/2, amp=[1,0,1,1,0])


### PR DESCRIPTION
  - fixes small typos
  - removes single quotation marks ‘ and ’ (see also issue #169)
  - removes double quotation marks “ and ” (see also issue #169)
  - adds some clarifying comments