### PR TITLE
Support for 'delay' keyword in the stutter method (Players)

### DIFF
--- a/FoxDot/lib/Players.py
+++ b/FoxDot/lib/Players.py
@@ -977,7 +977,13 @@ class Player(Repeatable):
 
             # Get PGroup delays
 
-            new_event["delay"] = PGroup([dur * (i+1) for i in range(max(n, self.get_event_length(new_event)))])
+            delay = kwargs.get("delay", new_event["delay"])
+
+            max_range = max(n, self.get_event_length(new_event))
+            new_event["delay"] = P([dur * (i+1) for i in range(max_range)])
+            new_event["delay"] += P(delay * PRange(max_range)) # if an additional delay is specified
+            # If delay is specified as a Pattern or a collection, it should be of len 'n',
+            # otherwise new events will be issued...
 
             new_event = self.get_prime_funcs(new_event)
 


### PR DESCRIPTION
`Players.stutter` allows to change some attribute of the generated events using patterns, for example:

    p1 >> play("  *   ", lpf=10000).every(1, "stutter", 10, lpf=10000*(0.7**PRange(10)))

but the events are all too close and the result is somewhat confused. This patchs allows to write

    p1 >> play("  *   ", lpf=10000).every(1, "stutter", 10, lpf=10000*(0.7**PRange(10)), delay=0.1225)

which separates the events with an additional period of time. There is also some support for Patterns, e.g.

    p1 >> play("  *   ", lpf=10000, delay=0.1).every(1, "stutter", 5, lpf=10000*(0.5**PRange(5)), delay=0.1 * PRange(5))

but this may need some additional testing.