### PR TITLE
Fixed import of urllib for > python3.X

### DIFF
--- a/FoxDot/lib/Extensions/VRender/Sinsy.py
+++ b/FoxDot/lib/Extensions/VRender/Sinsy.py
@@ -1,5 +1,5 @@
 import sys
-import urllib
+import urllib.request
 
 from functools import reduce
 
@@ -8,5 +8,4 @@ def download(output,wavPath):
 	index = text.find('./temp/') + len('./temp/')
 	text = text[index:index+40].split(".")[0]
 
-	testfile = urllib.URLopener()
-	testfile.retrieve("http://sinsy.sp.nitech.ac.jp/temp/" + text + ".wav", wavPath)
+	urllib.request.urlretrieve("http://sinsy.sp.nitech.ac.jp/temp/" + text + ".wav", wavPath)


### PR DESCRIPTION
I discovered through errors thrown that this library has changed a bit for python 3. 

I am not sure if this is correct cause on Sinsy's end I get a 404 NOT FOUND but it fixes the errors thrown. 