### PR TITLE
Configuration from environment variables

### DIFF
--- a/FoxDot/lib/Settings/__init__.py
+++ b/FoxDot/lib/Settings/__init__.py
@@ -91,9 +91,10 @@ def GET_TUTORIAL_FILES():
 
 # Set Environment Variables
 
-from . import conf
-
-reload(conf) # incase of a reload
+try:
+    reload(conf) # incase of a reload
+except NameError:
+    from . import conf
 
 FOXDOT_CONFIG_FILE  = conf.filename
     

--- a/FoxDot/lib/Settings/conf.py
+++ b/FoxDot/lib/Settings/conf.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 import sys
 
@@ -61,3 +62,10 @@ try:
         exec(code, globals())
 except FileNotFoundError:
     pass
+
+# Loading from env
+# ------------------
+
+for key, value in os.environ.items():
+    if key in globals():
+        globals()[key] = value

--- a/FoxDot/lib/Settings/conf.py
+++ b/FoxDot/lib/Settings/conf.py
@@ -1,6 +1,50 @@
 import os.path
 import sys
 
+# Settings
+# ------------------
+ADDRESS='localhost'
+PORT=57110
+PORT2=57120
+FONT='Consolas'
+SUPERCOLLIDER=""
+BOOT_ON_STARTUP=False
+CHECK_FOR_UPDATE=True
+SC3_PLUGINS=False
+MAX_CHANNELS=2
+SAMPLES_DIR=""
+GET_SC_INFO=True
+USE_ALPHA=True
+ALPHA_VALUE=0.8
+MENU_ON_STARTUP=True
+TRANSPARENT_ON_STARTUP=False
+RECOVER_WORK=True
+LINE_NUMBER_MARKER_OFFSET=0
+AUTO_COMPLETE_BRACKETS=True
+CPU_USAGE=2 # 0=low, 1=medium, 2=high
+CLOCK_LATENCY=0 # 0=low, 1=medium, 2=high
+FORWARD_ADDRESS=''
+FORWARD_PORT=0
+
+# Text colours
+# ------------------
+
+plaintext='#ffffff'
+background='#1a1a1a'
+functions='#bf4acc'
+key_types='#29abe2'
+user_defn='#29abe2'
+other_kws='#49db8b'
+comments='#666666'
+numbers='#e89c18'
+strings='#eae02a'
+dollar='#ec4e20'
+arrow='#eae02a'
+players='#ec4e20'
+
+# Loading from file
+# ------------------
+
 PY_VERSION = sys.version_info[0]
 
 if PY_VERSION == 2:
@@ -10,52 +54,10 @@ if PY_VERSION == 2:
 filename = os.path.join(os.path.dirname(__file__), "conf.txt")
 
 try:
-    
+
     with open(filename) as f:
-        for line in (l.strip() for l in f.readlines()):
-            if line and not line.startswith("#"):
-                code = compile(line, "FoxDot", "exec")
-                exec(code, globals())
-
+        contents = f.read()
+        code = compile(contents, "FoxDot", "exec")
+        exec(code, globals())
 except FileNotFoundError:
-
-    # Settings
-    # ------------------
-    ADDRESS='localhost'
-    PORT=57110
-    PORT2=57120
-    FONT='Consolas'
-    SUPERCOLLIDER=""
-    BOOT_ON_STARTUP=False
-    CHECK_FOR_UPDATE=True
-    SC3_PLUGINS=False
-    MAX_CHANNELS=2
-    SAMPLES_DIR=""
-    GET_SC_INFO=True
-    USE_ALPHA=True
-    ALPHA_VALUE=0.8
-    MENU_ON_STARTUP=True
-    TRANSPARENT_ON_STARTUP=False
-    RECOVER_WORK=True
-    LINE_NUMBER_MARKER_OFFSET=0
-    AUTO_COMPLETE_BRACKETS=True
-    CPU_USAGE=2 # 0=low, 1=medium, 2=high
-    CLOCK_LATENCY=0 # 0=low, 1=medium, 2=high
-    FORWARD_ADDRESS=''
-    FORWARD_PORT=0
-
-    # Text colours
-    # ------------------
-
-    plaintext='#ffffff'
-    background='#1a1a1a'
-    functions='#bf4acc'
-    key_types='#29abe2'
-    user_defn='#29abe2'
-    other_kws='#49db8b'
-    comments='#666666'
-    numbers='#e89c18'
-    strings='#eae02a'
-    dollar='#ec4e20'
-    arrow='#eae02a'
-    players='#ec4e20'
+    pass


### PR DESCRIPTION
This patch allows to set configuration from env vars without writing to the conf file, primarily intended for editor plugins.

I changed the position of default values to clearly follow the logic:

1. Default values are set.
1. Conf file can override values.
1. Env vars can override values.
