### PR TITLE
Allow connection to remote SuperCollider

### DIFF
--- a/FoxDot/lib/ServerManager.py
+++ b/FoxDot/lib/ServerManager.py
@@ -213,7 +213,12 @@ class SCLangServerManager(ServerManager):
 
         # OSC Connection for custom OSCFunc in SuperCollider
         if GET_SC_INFO:
-            self.sclang = BidirectionalOSCServer()
+            # Prevent SocketError when connecting to a remote FoxDot instance
+            server_address=('0.0.0.0', 0)
+            if (self.addr == 'localhost' or self.addr == '127.0.0.1'):
+                server_address=('localhost', 0)
+
+            self.sclang = BidirectionalOSCServer(server_address=server_address)
             self.sclang.connect( (self.addr, self.SCLang_port) )
             self.loadSynthDef(FOXDOT_INFO_FILE)
             try:

--- a/FoxDot/lib/Settings/__init__.py
+++ b/FoxDot/lib/Settings/__init__.py
@@ -122,6 +122,19 @@ if conf.SAMPLES_DIR is not None and conf.SAMPLES_DIR != "":
 
     FOXDOT_SND = os.path.realpath(conf.SAMPLES_DIR)
 
+# Recreate info file from template
+if os.path.isfile(FOXDOT_INFO_FILE):
+    os.remove(FOXDOT_INFO_FILE)
+
+try:
+    with open(FOXDOT_INFO_FILE+".template", "r") as fread:
+        content = fread.read()
+        content = content.replace("<FOXDOT_SND>", f"'{FOXDOT_SND}'")
+        with open(FOXDOT_INFO_FILE, "w") as f:
+            f.write(content)
+except FileNotFoundError:
+    pass
+
 def get_timestamp():
     import time
     return time.strftime("%Y%m%d-%H%M%S")

--- a/FoxDot/lib/Settings/__init__.py
+++ b/FoxDot/lib/Settings/__init__.py
@@ -129,6 +129,7 @@ if os.path.isfile(FOXDOT_INFO_FILE):
 try:
     with open(FOXDOT_INFO_FILE+".template", "r") as fread:
         content = fread.read()
+        content = content.replace("<FOXDOT_ROOT>", f"'{FOXDOT_ROOT}'")
         content = content.replace("<FOXDOT_SND>", f"'{FOXDOT_SND}'")
         with open(FOXDOT_INFO_FILE, "w") as f:
             f.write(content)

--- a/FoxDot/osc/Info.scd.template
+++ b/FoxDot/osc/Info.scd.template
@@ -13,6 +13,7 @@ OSCFunc(
         Server.default.options.numBuffers,
         Server.default.options.maxNodes,
         Server.default.options.maxSynthDefs,
+        <FOXDOT_SND>,
     );
     }, '/foxdot/info'
 );

--- a/FoxDot/osc/Info.scd.template
+++ b/FoxDot/osc/Info.scd.template
@@ -13,6 +13,7 @@ OSCFunc(
         Server.default.options.numBuffers,
         Server.default.options.maxNodes,
         Server.default.options.maxSynthDefs,
+        <FOXDOT_ROOT>,
         <FOXDOT_SND>,
     );
     }, '/foxdot/info'


### PR DESCRIPTION
This issue addresses points 1-3 in #242.

The least intrusive solution I thought about was retrieving the proper path prefixes when retrieving the server info. This has the drawback of leaking information about the server setup that shouldn't be known by the client, which is problematic if this approach is to be used in an eventual "serious" service or in a public network. However, for personal and controlled used it's enough and doesn't require any heavy code or project refactoring.