### PR TITLE
Fix bug: Don't ask for filename upon every save

### DIFF
--- a/FoxDot/lib/Workspace/Editor.py
+++ b/FoxDot/lib/Workspace/Editor.py
@@ -667,9 +667,13 @@ class workspace:
         """ Saves the contents of the text editor """
         text = self.text.get("0.0",END)
 
-        if not self.saved:
+        if self.saved:
+            return True
+
+        if not self.filename:
             self.filename = tkFileDialog.asksaveasfilename(filetypes=[("Python files", ".py")],
                                                            defaultextension=".py")
+
         if self.filename:
 
             write_to_file(self.filename, text)
@@ -712,6 +716,8 @@ class workspace:
             f = open(path)
             text = f.read()
             f.close()
+            self.saved = True
+            self.filename = path
             self.set_all(text)
             self.set_window_title(path)
         return "break"


### PR DESCRIPTION
Save code was not reading from correct properties. It would always ask the user for a filename when saving. This would even happening when saving an unchanged file that had just been opened. This change fixes these issues.