### PR TITLE
Refactor inspect.getargspec() -> getfullargspec(), .keywords->.varkw

### DIFF
--- a/FoxDot/lib/Effects/NewEffects.py
+++ b/FoxDot/lib/Effects/NewEffects.py
@@ -14,7 +14,7 @@ class _Effect:
         self.lines = []
     def __call__(self, order=0):
         def decorator(effect):
-            effect_data = inspect.getargspec(effect) # Original args and defaults
+            effect_data = inspect.getfullargspec(effect) # Original args and defaults
             
             # Get filename from function name
             filename = "{}.scd".format(effect.__name__)# filename

--- a/FoxDot/lib/Patterns/Main.py
+++ b/FoxDot/lib/Patterns/Main.py
@@ -34,7 +34,7 @@ def loop_pattern_func(f):
         for i in range(LCM(*[len(arg) for arg in args if (hasattr(arg, '__len__') and not isinstance(arg, PGroup))])):
             pat |= f(*[(arg[i] if isinstance(arg, Pattern) else arg) for arg in args])
         return pat
-    new_function.argspec = inspect.getargspec(f)
+    new_function.argspec = inspect.getfullargspec(f)
     return new_function
 
 # TODO -- if it isn't looped, return the original if it is a group
@@ -58,7 +58,7 @@ def loop_pattern_method(f):
             pat |= f(self, *[(modi(arg, i) if not isinstance(arg, PGroup) else arg) for arg in args])
         return pat
 
-    new_function.argspec = inspect.getargspec(f)
+    new_function.argspec = inspect.getfullargspec(f)
     return new_function
 
 def PatternMethod(f):

--- a/FoxDot/lib/Repeat.py
+++ b/FoxDot/lib/Repeat.py
@@ -424,7 +424,7 @@ class MethodCall:
 
         # Check if a method has the _beat_ keyword argument
 
-        if "_beat_" in inspect.getargspec(self.method).args:
+        if "_beat_" in inspect.getfullargspec(self.method).args:
 
             self.kwargs["_beat_"] = None
 

--- a/FoxDot/lib/TempoClock.py
+++ b/FoxDot/lib/TempoClock.py
@@ -760,20 +760,20 @@ class Queue(object):
         """ Adds a callable object to the queue at a specified beat, args and kwargs for the
             callable object must be in a list and dict.
         """
-        
+
         # item must be callable to be schedule, so check args and kwargs are appropriate for it
 
         try:
 
-            function = inspect.getargspec(item)
+            function = inspect.getfullargspec(item)
 
         except TypeError:
 
-            function = inspect.getargspec(item.__call__)
+            function = inspect.getfullargspec(item.__call__)
 
         # If the item can't take arbitrary keywords, check any kwargs are valid
 
-        if function.keywords is None: 
+        if function.varkw is None:
 
             for key in list(kwargs.keys()):
 


### PR DESCRIPTION
- This gets FoxDot working with python3.12 and sclang v3.13.0 (`dnf install -y supercollider`)
- inspect.getargspec is now inspect.getfullargspec
  - it's `varkw` instead of `keywords` now
    - https://stackoverflow.com/questions/54999951/python-2-3-compatible-way-of-inspecting-methods-arguments/55000090#55000090
